### PR TITLE
fix: Method too large

### DIFF
--- a/antlr-kotlin-runtime-common/src/main/kotlin/com/strumenta/kotlinmultiplatform/Misc.kt
+++ b/antlr-kotlin-runtime-common/src/main/kotlin/com/strumenta/kotlinmultiplatform/Misc.kt
@@ -47,10 +47,9 @@ expect class BitSet {
 
 expect object Collections {
     fun unmodifiableList(asList: Collection<*>): List<*>
-    fun <T, U> unmodifiableMap(t: T): U
+    fun <T, U> unmodifiableMap(map: Map<T, U>): MutableMap<T, U>
     fun <T : Comparable<T>> min(precedencePredicates: List<T>): T
     fun <T : Comparable<T>> max(precedencePredicates: List<T>): T
-
 }
 
 expect object Math {

--- a/antlr-kotlin-runtime-js/src/main/kotlin/com/strumenta/kotlinmultiplatform/Collections.kt
+++ b/antlr-kotlin-runtime-js/src/main/kotlin/com/strumenta/kotlinmultiplatform/Collections.kt
@@ -5,7 +5,7 @@ actual object Collections {
         return asList.toList()
     }
 
-    actual fun <T, U> unmodifiableMap(t: T): U {
+    actual fun <T, U> unmodifiableMap(map: Map<T, U>): MutableMap<T, U> {
         TODO("Collections.unmodifiableMap not implemented") //To change body of created functions use File | Settings | File Templates.
     }
 

--- a/antlr-kotlin-runtime-jvm/src/main/kotlin/com/strumenta/kotlinmultiplatform/Collections.kt
+++ b/antlr-kotlin-runtime-jvm/src/main/kotlin/com/strumenta/kotlinmultiplatform/Collections.kt
@@ -5,16 +5,16 @@ actual object Collections {
         return asList.toList()
     }
 
-    actual fun <T, U> unmodifiableMap(t: T): U {
-        TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    actual fun <T, U> unmodifiableMap(map: Map<T, U>): MutableMap<T, U> {
+        return java.util.Collections.unmodifiableMap(map)
     }
 
     actual fun <T : Comparable<T>> min(precedencePredicates: List<T>): T {
-        TODO()
+        return java.util.Collections.min(precedencePredicates)
     }
 
     actual fun <T : Comparable<T>> max(precedencePredicates: List<T>): T {
-        TODO()
+        return java.util.Collections.max(precedencePredicates)
     }
 
 }

--- a/antlr-kotlin-target/src/main/java/org/antlr/v4/codegen/target/KotlinTarget.java
+++ b/antlr-kotlin-target/src/main/java/org/antlr/v4/codegen/target/KotlinTarget.java
@@ -77,7 +77,7 @@ public class KotlinTarget extends Target {
 	public int getSerializedATNSegmentLimit() {
 		// 65535 is the class file format byte limit for a UTF-8 encoded string literal
 		// 3 is the maximum number of bytes it takes to encode a value in the range 0-0xFFFF
-		return 65535 / 3;
+		return 65535 / 6;
 	}
 
 	@Override
@@ -145,7 +145,11 @@ public class KotlinTarget extends Target {
 
 	@Override
 	public String encodeIntAsCharEscape(int v) {
-		return Integer.toString(v);
+		if (v < Character.MIN_VALUE || v > Character.MAX_VALUE) {
+			throw new IllegalArgumentException(String.format("Cannot encode the specified value: %d", v));
+		}
+
+		return "\\u" + Integer.toHexString(v | 0x10000).substring(1, 5);
 	}
 
 	@Override

--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -52,6 +52,7 @@ package <file.genPackage>;
 import com.strumenta.kotlinmultiplatform.Arrays
 import com.strumenta.kotlinmultiplatform.getType
 import com.strumenta.kotlinmultiplatform.TypeDeclarator
+import org.antlr.v4.runtime.misc.Utils;
 import org.antlr.v4.kotlinruntime.*
 import org.antlr.v4.kotlinruntime.atn.*
 import org.antlr.v4.kotlinruntime.atn.ATNDeserializer
@@ -266,7 +267,7 @@ class <parser.name>(input: TokenStream) : <superClass; null="Parser">(input) {
 	    protected val decisionToDFA : Array\<DFA>
     	protected val sharedContextCache = PredictionContextCache()
 
-        val ruleNames = arrayOf(<parser.ruleNames:{r | "<r>"}; separator=", ", wrap, anchor>)
+        val ruleNames = listOf(<parser.ruleNames:{r | "<r>"}; separator=", ", wrap, anchor>).toTypedArray()
 
         <vocabulary(parser.literalNames, parser.symbolicNames)>
 
@@ -473,8 +474,8 @@ this.state = <choice.stateNumber>
 errorHandler.sync(this)
 when (_input!!.LA(1)) {
 <choice.altLook,alts:{look,alt| <cases(ttypes=look)>
-	<alt>}; separator="\n">
-else -> ;
+	<if(alt)><alt><else>Unit<endif>}; separator="\n">
+else -> Unit
 }
 >>
 
@@ -839,6 +840,7 @@ package <lexerFile.genPackage>
 <endif>
 <namedActions.header>
 import com.strumenta.kotlinmultiplatform.Arrays
+import org.antlr.v4.runtime.misc.Utils
 import org.antlr.v4.kotlinruntime.CharStream
 import org.antlr.v4.kotlinruntime.Lexer
 import org.antlr.v4.kotlinruntime.VocabularyImpl
@@ -923,21 +925,18 @@ class <lexer.name>(val input: CharStream) : <superClass; null="Lexer">(input) {
 SerializedATN(model) ::= <<
 <if(rest(model.segments))>
 <! requires segmented representation !>
-private static final int _serializedATNSegments = <length(model.segments)>;
-<model.segments:{segment|private static final String _serializedATNSegment<i0> =
-	"<segment; wrap={"+<\n><\t>"}>";}; separator="\n">
-public static final String _serializedATN = Utils.join(
-	new String[] {
-		<model.segments:{segment | _serializedATNSegment<i0>}; separator=",\n">
-	},
+<model.segments:{segment|private const val serializedATNSegment<i0> : String =
+	"<segment>";}; separator="\n">
+private val serializedATN : String = Utils.join(
+	listOf(<model.segments:{segment | serializedATNSegment<i0>}; separator=",\n">).iterator(),
 	""
-);
+)
 <else>
 <! only one segment, can be inlined !>
-private val serializedIntegersATN =
-	arrayOf(<model.serialized:{it | <it>}; wrap={<\n><\t>}, separator=", ">)
+private const val serializedATN : String = "<model.serialized>"
+
 <endif>
-val ATN = ATNDeserializer().deserializeIntegers(serializedIntegersATN)
+val ATN = ATNDeserializer().deserializeIntegers(serializedATN.asSequence().map { it.toInt() }.toList().toTypedArray())
 init {
 	decisionToDFA = Array\<DFA>(ATN.numberOfDecisions, {
 		DFA(ATN.getDecisionState(it)!!, it)
@@ -953,21 +952,18 @@ init {
 SerializedATNEnriched(model) ::= <<
 <if(rest(model.segments))>
 <! requires segmented representation !>
-private static final int _serializedATNSegments = <length(model.segments)>;
-<model.segments:{segment|private static final String _serializedATNSegment<i0> =
-	"<segment; wrap={"+<\n><\t>"}>";}; separator="\n">
-public static final String _serializedATN = Utils.join(
-	new String[] {
-		<model.segments:{segment | _serializedATNSegment<i0>}; separator=",\n">
-	},
+<model.segments:{segment|private const val serializedATNSegment<i0> : String  =
+	"<segment>";}; separator="\n">
+private val serializedATN : String = Utils.join(
+	listOf(<model.segments:{segment | serializedATNSegment<i0>}; separator=",\n">).iterator(),
 	""
 );
 <else>
 <! only one segment, can be inlined !>
-val serializedIntegersATN =
-	arrayOf(<model.serializedIntegers; wrap={<\n><\t>}, separator=",">)
+private const val serializedATN : String = "<model.serialized>"
+
 <endif>
-val ATN = ATNDeserializer().deserializeIntegers(serializedIntegersATN)
+val ATN = ATNDeserializer().deserializeIntegers(serializedATN.asSequence().map { it.toInt() }.toList().toTypedArray())
 init {
 	decisionToDFA = Array\<DFA>(ATN.numberOfDecisions, {
 		DFA(ATN.getDecisionState(it)!!, it)


### PR DESCRIPTION
**arrayOf** is a **inline** method in Kotlin (at least since 1.2.71), so its usage for **serializedIntegersATN** causes a "Method too large!" exception during compilation.

P.S. I'm sorry for my English 