### PR TITLE
Add iOS to supported targets

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -9,7 +9,7 @@ It means:
 * the **Kotlin target**: this is a plugin for the ANTLR code generator that produces lexers, parsers, and listeners
 * the **Kotlin runtime library**: this is a multi-platform library needed to run the lexers and parsers
 
-Because we produce multi-platform code and a multi-platform runtime, the code written using the Kotlin target for ANTLR can run on the JVM, in the browser, and natively on Mac, Windows, and Linux.
+Because we produce multi-platform code and a multi-platform runtime, the code written using the Kotlin target for ANTLR can run on the JVM (including Android), in the browser, and natively on Mac, Windows, Linux, and iOS.
 
 ## Status
 

--- a/antlr-kotlin-runtime/build.gradle.kts
+++ b/antlr-kotlin-runtime/build.gradle.kts
@@ -18,16 +18,22 @@ kotlin {
         }
     }
 
-    // Create a target for the host platform.
-    val hostTarget = System.getProperty("os.name").let { hostOs ->
-        when {
-            hostOs == "Mac OS X" -> macosX64("native")
-            hostOs == "Linux" -> linuxX64("native")
-            hostOs.startsWith("Windows") -> mingwX64("native")
-            else -> null
+    ios("ios") {
+        binaries {
+            staticLib()
         }
     }
-    hostTarget?.apply {
+    linuxX64("linux") {
+        binaries {
+            staticLib()
+        }
+    }
+    macosX64("mac") {
+        binaries {
+            staticLib()
+        }
+    }
+    mingwX64("windows") {
         binaries {
             staticLib()
         }
@@ -68,9 +74,19 @@ kotlin {
                 implementation(kotlin("test-js"))
             }
         }
-        val nativeMain by getting {
+        val nativeMain by creating {
         }
-        val nativeTest by getting {
+        val iosMain by getting {
+            dependsOn(nativeMain)
+        }
+        val linuxMain by getting {
+            dependsOn(nativeMain)
+        }
+        val macMain by getting {
+            dependsOn(nativeMain)
+        }
+        val windowsMain by getting {
+            dependsOn(nativeMain)
         }
     }
 }

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Parser.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Parser.kt
@@ -678,10 +678,7 @@ abstract class Parser(input: TokenStream) : Recognizer<Token, ParserATNSimulator
     }
 
 
-    @Deprecated(
-            "Use\n" +
-                    "\t  {@link #enterRecursionRule(ParserRuleContext, int, int, int)} instead."
-    )
+    @Deprecated("Use {@link #enterRecursionRule(ParserRuleContext, int, int, int)} instead.")
     fun enterRecursionRule(localctx: ParserRuleContext, ruleIndex: Int) {
         enterRecursionRule(localctx, atn.ruleToStartState!![ruleIndex]!!.stateNumber, ruleIndex, 0)
     }

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Recognizer.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Recognizer.kt
@@ -186,11 +186,12 @@ abstract class Recognizer<Symbol, ATNInterpreter : ATNSimulator> {
      * your token objects because you don't have to go modify your lexer
      * so that it creates a new Java type.
      *
+     * This method is not called by the ANTLR 4 Runtime. Specific
+     * implementations of [ANTLRErrorStrategy] may provide a similar
+     * feature when necessary. For example, see
+     * [DefaultErrorStrategy.getTokenErrorDisplay].
      */
-    @Deprecated("This method is not called by the ANTLR 4 Runtime. Specific\n" +
-            "\t  implementations of {@link ANTLRErrorStrategy} may provide a similar\n" +
-            "\t  feature when necessary. For example, see\n" +
-            "\t  {@link DefaultErrorStrategy#getTokenErrorDisplay}.")
+    @Deprecated("""This method is not called by the ANTLR 4 Runtime.""")
     fun getTokenErrorDisplay(t: Token?): String {
         if (t == null) return "<no token>"
         var s: String? = t.text

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/RuleTransition.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/RuleTransition.kt
@@ -22,8 +22,7 @@ class RuleTransition(ruleStart: RuleStartState,
         get() = true
 
 
-    @Deprecated("Use\n" +
-            "\t  {@link #RuleTransition(RuleStartState, int, int, ATNState)} instead.")
+    @Deprecated("Use {@link #RuleTransition(RuleStartState, int, int, ATNState)} instead.")
     constructor(ruleStart: RuleStartState,
                 ruleIndex: Int,
                 followState: ATNState) : this(ruleStart, ruleIndex, 0, followState) {

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/NotNull.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/NotNull.kt
@@ -6,6 +6,5 @@
 package org.antlr.v4.kotlinruntime.misc
 
 @Target(AnnotationTarget.FIELD, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER, AnnotationTarget.PROPERTY_SETTER, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.LOCAL_VARIABLE)
-@Deprecated("THIS IS HERE FOR BACKWARD COMPATIBILITY WITH 4.5 ONLY.  It will\n" +
-        "   disappear in 4.6+")
+@Deprecated("THIS IS HERE FOR BACKWARD COMPATIBILITY WITH 4.5 ONLY.  It will disappear in 4.6+")
 annotation class NotNull


### PR DESCRIPTION
I've tested this on a Mac OS host, and it's working as expected.

We don't need host detection, because the Kotlin gradle plugin handles that automatically. Only the targets supported by the current host platform will be exposed as gradle tasks.

On OS X, I was able to build JS, JVM, Linux, OS X, and all the iOS targets at once, and publish to maven local.

I discovered a bug in Kotlin's Apple framework export: If the klib is used to generate an iOS framework, Xcode will not compile due to a silly string escape issue (https://youtrack.jetbrains.com/issue/KT-39206). I've fixed this by removing the `\n` escapes in the Kotlin code causing the issue :)