### PR TITLE
Fix Lexer/Parser for Kotlin/Native immutability

### DIFF
--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/ParseCancellationException.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/ParseCancellationException.kt
@@ -21,15 +21,13 @@ class ParseCancellationException : RuntimeException {
 
     constructor() {}
 
-    constructor(message: String) {}
+    constructor(message: String) : super (message) {}
 
-    constructor(cause: Throwable) {
-        TODO()
+    constructor(cause: Throwable) : super(cause) {
         //initCause(cause)
     }
 
-    constructor(message: String, cause: Throwable) {
-        TODO()
+    constructor(message: String, cause: Throwable) : super(message, cause) {
         //initCause(cause)
     }
 

--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -62,6 +62,7 @@ import org.antlr.v4.kotlinruntime.tree.ParseTreeListener
 import org.antlr.v4.kotlinruntime.tree.TerminalNode
 import org.antlr.v4.kotlinruntime.atn.ATN.Companion.INVALID_ALT_NUMBER
 import org.antlr.v4.kotlinruntime.tree.ParseTreeVisitor
+import kotlin.native.concurrent.ThreadLocal
 import kotlin.reflect.KClass
 
 <parser>
@@ -263,6 +264,7 @@ class <parser.name>(input: TokenStream) : <superClass; null="Parser">(input) {
         <parser.rules:{r | RULE_<r.name>(<r.index>)}; separator=",\n", wrap, anchor>
     }
 
+    @ThreadLocal
 	companion object {
 	    protected val decisionToDFA : Array\<DFA>
     	protected val sharedContextCache = PredictionContextCache()
@@ -849,6 +851,7 @@ import org.antlr.v4.kotlinruntime.atn.ATNDeserializer
 import org.antlr.v4.kotlinruntime.atn.LexerATNSimulator
 import org.antlr.v4.kotlinruntime.atn.PredictionContextCache
 import org.antlr.v4.kotlinruntime.dfa.DFA
+import kotlin.native.concurrent.ThreadLocal
 
 <lexer>
 >>
@@ -866,6 +869,7 @@ class <lexer.name>(val input: CharStream) : <superClass; null="Lexer">(input) {
     override val atn: ATN
 		get() = <lexer.name>.Companion.ATN
 
+    @ThreadLocal
 	companion object {
 		val decisionToDFA : Array\<DFA>
 		val sharedContextCache = PredictionContextCache()


### PR DESCRIPTION
Annotated companion objects in Lexer and Parser with @ThreadLocal to address immutability in Kotlin/Native. See https://github.com/JetBrains/kotlin-native/blob/master/IMMUTABILITY.md