### PR TITLE
runtime: unrollRecursionContexts() should consider null parent context.

### DIFF
--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Parser.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Parser.kt
@@ -719,7 +719,7 @@ abstract class Parser(input: TokenStream) : Recognizer<Token, ParserATNSimulator
 
         while (context !== _parentctx) {
             triggerExitRuleEvent()
-            context = context!!.readParent() as ParserRuleContext
+            context = context!!.readParent() as ParserRuleContext?
         }
 
         // hook into tree


### PR DESCRIPTION
Fixes https://github.com/Strumenta/antlr-kotlin/issues/60.

There are some possible case where parent context is null (which most likely
happens if the root is a left recursion), but Kotlin `as` operator acts
as non-null cast or NullPointerException. This fix treats parent as nullable.