### PR TITLE
mark `EMPTY_RULECTX` as `@SharedImmutable` for iOS

### DIFF
--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/RuleContext.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/RuleContext.kt
@@ -5,6 +5,7 @@
  */
 package org.antlr.v4.kotlinruntime
 
+import kotlin.native.concurrent.SharedImmutable
 import org.antlr.v4.kotlinruntime.atn.ATN
 import org.antlr.v4.kotlinruntime.misc.Interval
 import org.antlr.v4.kotlinruntime.tree.ParseTree
@@ -63,6 +64,7 @@ import org.antlr.v4.kotlinruntime.tree.Trees
  * @see ParserRuleContext
  */
 
+@SharedImmutable
 val EMPTY_RULECTX = ParserRuleContext()
 
 


### PR DESCRIPTION
I'm working on a cross platform parser for Android & iOS, and get the following crash when trying to use the parser from an iOS background thread:

```
kotlin.native.IncorrectDereferenceException: Trying to access top level value not marked as @ThreadLocal or @SharedImmutable from non-main thread
	at kotlin.Throwable#<init>(/Users/teamcity2/buildAgent/work/7c4fade2802b7783/kotlin/kotlin-native/runtime/src/main/kotlin/kotlin/Throwable.kt:23)
	at kotlin.Exception#<init>(/Users/teamcity2/buildAgent/work/7c4fade2802b7783/kotlin/kotlin-native/runtime/src/main/kotlin/kotlin/Exceptions.kt:23)
	at kotlin.RuntimeException#<init>(/Users/teamcity2/buildAgent/work/7c4fade2802b7783/kotlin/kotlin-native/runtime/src/main/kotlin/kotlin/Exceptions.kt:34)
	at kotlin.native.IncorrectDereferenceException#<init>(/Users/teamcity2/buildAgent/work/7c4fade2802b7783/kotlin/kotlin-native/runtime/src/main/kotlin/kotlin/native/Runtime.kt:30)
	at <global>.ThrowIncorrectDereferenceException(/Users/teamcity2/buildAgent/work/7c4fade2802b7783/kotlin/kotlin-native/runtime/src/main/kotlin/kotlin/native/internal/RuntimeUtils.kt:104)
	at <global>.CheckGlobalsAccessible(Unknown Source)
	at org.antlr.v4.kotlinruntime#<get-EMPTY_RULECTX>(/Users/runner/work/antlr-kotlin/antlr-kotlin/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/RuleContext.kt:66)
	at org.antlr.v4.kotlinruntime.atn.ParserATNSimulator#adaptivePredict(/Users/runner/work/antlr-kotlin/antlr-kotlin/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ParserATNSimulator.kt:366)
	at org.cru.godtools.expressions.internal.grammar.ExpressionParser.expr#internal(/Users/frett/development/kotlin/godtools-tool-parser/module/expressions/build/generated/source/antlr/commonMain/org/cru/godtools/expressions/internal/grammar/ExpressionParser.kt:312)
	at org.cru.godtools.expressions.internal.grammar.ExpressionParser#expr(/Users/frett/development/kotlin/godtools-tool-parser/module/expressions/build/generated/source/antlr/commonMain/org/cru/godtools/expressions/internal/grammar/ExpressionParser.kt:233)
```

From what I can tell, the `EMPTY_RULECTX` should be marked as `@SharedImmutable` because it isn't modified and is just used as a placeholder in a few places.