### PR TITLE
JS implementation of Collections.kt, copied from the native implementation

### DIFF
--- a/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/kotlinmultiplatform/Collections.kt
+++ b/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/kotlinmultiplatform/Collections.kt
@@ -19,11 +19,11 @@ package com.strumenta.kotlinmultiplatform
 actual object Collections {
 
     actual fun <T : Comparable<T>> min(precedencePredicates: List<T>): T {
-        TODO("Collections.min not implemented") //To change body of created functions use File | Settings | File Templates.
+        return precedencePredicates.minOrNull() ?: throw NoSuchElementException()
     }
 
     actual fun <T : Comparable<T>> max(precedencePredicates: List<T>): T {
-        TODO("Collections.max not implemented") //To change body of created functions use File | Settings | File Templates.
+        return precedencePredicates.maxOrNull() ?: throw NoSuchElementException()
     }
 
 }


### PR DESCRIPTION
A simple implementation of Collections.min and Collections.max for JS.

This is a copy of the [existing native](https://github.com/Strumenta/antlr-kotlin/blob/160bc0b70f2cb3fb1be5af00b55777ec01c8f951/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/kotlinmultiplatform/Collections.kt) implementation.

The [JVM implementation](https://github.com/Strumenta/antlr-kotlin/blob/160bc0b70f2cb3fb1be5af00b55777ec01c8f951/antlr-kotlin-runtime/src/jvmMain/kotlin/com/strumenta/kotlinmultiplatform/Collections.kt) instead uses `java.util.Collections.min` and `java.util.Collections.max`. However, the native/JS implementation should also work under JVM - would it be better to add this implementation to `commonMain` and remove the platform-specific implementations?