### PR TITLE
Uncomment crucial precpred override

### DIFF
--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Parser.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Parser.kt
@@ -740,9 +740,9 @@ abstract class Parser(input: TokenStream) : Recognizer<Token, ParserATNSimulator
 //        return null
 //    }
 //
-//    override fun precpred(localctx: RuleContext, precedence: Int): Boolean {
-//        return precedence >= _precedenceStack.peek()
-//    }
+    override fun precpred(localctx: RuleContext, precedence: Int): Boolean {
+        return precedence >= _precedenceStack.peek()
+    }
 //
 //    fun inContext(context: String): Boolean {
 //        // TODO: useful in parser?


### PR DESCRIPTION
This is required for precedence to work properly. I'm not sure why it's commented out but it took me a solid day to track down.