### PR TITLE
Allow testing syntax errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,11 @@ To start using ANTLR Kotlin:
      dependsOn("cleanGenerateKotlinGrammarSource")
 
      // ANTLR .g4 files are under {example-project}/antlr
-     setSource(layout.projectDirectory.dir("antlr"))
+     // Only include *.g4 files. This allows tools (e.g., IDE plugins)
+     // to generate temporary files inside the base path
+     source = fileTree(layout.projectDirectory.dir("antlr")) {
+       include("**/*.g4")
+     }
 
      // We want the generated source files to have this package name
      val pkgName = "com.strumenta.antlrkotlin.parsers.generated"

--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -980,29 +980,38 @@ SerializedJavaATN(model) ::= <<
 <if(rest(model.segments))>
 <! requires segmented representation !>
 <model.segments:{segment|private const val SERIALIZED_ATN_SEGMENT<i0>: String =
-    "<segment>";}; separator="\n">
-private val SERIALIZED_ATN: String =
-    listOf(<model.segments:{segment | SERIALIZED_ATN_SEGMENT<i0>}; separator=",\n">).joinToString("")
+    "<segment>"
+}; separator="\n">
+
+private val SERIALIZED_ATN = buildString(65535 / 3 * <length(model.segments)>) {
+    <model.segments:{segment | append(SERIALIZED_ATN_SEGMENT<i0>)}; separator="\n">
+}
+
 <else>
 <! only one segment, can be inlined !>
 private const val SERIALIZED_ATN: String =
     "<model.serialized>"
-<endif>
 
+<endif>
 private val ATN = ATNDeserializer().deserialize(SERIALIZED_ATN.toCharArray())
 >>
 
 SerializedATNEnriched(model) ::= <<
 <if(rest(model.segments))>
 <! requires segmented representation !>
-<model.segments:{segment|private const val SERIALIZED_ATN_SEGMENT<i0>: String  =
-    "<segment>";}; separator="\n">
-private val SERIALIZED_ATN: String =
-    listOf(<model.segments:{segment | SERIALIZED_ATN_SEGMENT<i0>}; separator=",\n">).joinToString("")
+<model.segments:{segment|private const val SERIALIZED_ATN_SEGMENT<i0>: String =
+    "<segment>"
+}; separator="\n">
+
+private val SERIALIZED_ATN = buildString(65535 / 3 * <length(model.segments)>) {
+    <model.segments:{segment | append(SERIALIZED_ATN_SEGMENT<i0>)}; separator="\n">
+}
+
 <else>
 <! only one segment, can be inlined !>
 private const val SERIALIZED_ATN: String =
     "<model.serialized>"
+
 <endif>
 private val ATN = ATNDeserializer().deserialize(SERIALIZED_ATN.toCharArray())
 >>

--- a/antlr-kotlin-tests/antlr/VisualBasic6Lexer.g4
+++ b/antlr-kotlin-tests/antlr/VisualBasic6Lexer.g4
@@ -1,0 +1,471 @@
+// $antlr-format alignTrailingComments true, columnLimit 150, maxEmptyLinesToKeep 1, reflowComments false, useTab false
+// $antlr-format allowShortRulesOnASingleLine true, allowShortBlocksOnASingleLine true, minEmptyLines 0, alignSemicolons ownLine
+// $antlr-format alignColons trailing, singleLineOverrulesHangingColon true, alignLexerCommands true, alignLabels true, alignTrailers true
+
+lexer grammar VisualBasic6Lexer;
+
+options {
+    caseInsensitive = true;
+}
+
+// keywords
+
+ACCESS: 'ACCESS';
+
+ADDRESSOF: 'ADDRESSOF';
+
+ALIAS: 'ALIAS';
+
+AND: 'AND';
+
+ATTRIBUTE: 'ATTRIBUTE';
+
+APPACTIVATE: 'APPACTIVATE';
+
+APPEND: 'APPEND';
+
+AS: 'AS';
+
+BEEP: 'BEEP';
+
+BEGIN: 'BEGIN';
+
+BEGINPROPERTY: 'BEGINPROPERTY';
+
+BINARY: 'BINARY';
+
+BOOLEAN: 'BOOLEAN';
+
+BYVAL: 'BYVAL';
+
+BYREF: 'BYREF';
+
+BYTE: 'BYTE';
+
+CALL: 'CALL';
+
+CASE: 'CASE';
+
+CHDIR: 'CHDIR';
+
+CHDRIVE: 'CHDRIVE';
+
+CLASS: 'CLASS';
+
+CLOSE: 'CLOSE';
+
+COLLECTION: 'COLLECTION';
+
+CONST: 'CONST';
+
+DATE: 'DATE';
+
+DECLARE: 'DECLARE';
+
+DEFBOOL: 'DEFBOOL';
+
+DEFBYTE: 'DEFBYTE';
+
+DEFDATE: 'DEFDATE';
+
+DEFDBL: 'DEFDBL';
+
+DEFDEC: 'DEFDEC';
+
+DEFCUR: 'DEFCUR';
+
+DEFINT: 'DEFINT';
+
+DEFLNG: 'DEFLNG';
+
+DEFOBJ: 'DEFOBJ';
+
+DEFSNG: 'DEFSNG';
+
+DEFSTR: 'DEFSTR';
+
+DEFVAR: 'DEFVAR';
+
+DELETESETTING: 'DELETESETTING';
+
+DIM: 'DIM';
+
+DO: 'DO';
+
+DOUBLE: 'DOUBLE';
+
+EACH: 'EACH';
+
+ELSE: 'ELSE';
+
+ELSEIF: 'ELSEIF';
+
+END_ENUM: 'END ENUM';
+
+END_FUNCTION: 'END FUNCTION';
+
+END_IF: 'END IF';
+
+END_PROPERTY: 'END PROPERTY';
+
+END_SELECT: 'END SELECT';
+
+END_SUB: 'END SUB';
+
+END_TYPE: 'END TYPE';
+
+END_WITH: 'END WITH';
+
+END: 'END';
+
+ENDPROPERTY: 'ENDPROPERTY';
+
+ENUM: 'ENUM';
+
+EQV: 'EQV';
+
+ERASE: 'ERASE';
+
+ERROR: 'ERROR';
+
+EVENT: 'EVENT';
+
+EXIT_DO: 'EXIT DO';
+
+EXIT_FOR: 'EXIT FOR';
+
+EXIT_FUNCTION: 'EXIT FUNCTION';
+
+EXIT_PROPERTY: 'EXIT PROPERTY';
+
+EXIT_SUB: 'EXIT SUB';
+
+FALSE: 'FALSE';
+
+FILECOPY: 'FILECOPY';
+
+FRIEND: 'FRIEND';
+
+FOR: 'FOR';
+
+FUNCTION: 'FUNCTION';
+
+GET: 'GET';
+
+GLOBAL: 'GLOBAL';
+
+GOSUB: 'GOSUB';
+
+GOTO: 'GOTO';
+
+IF: 'IF';
+
+IMP: 'IMP';
+
+IMPLEMENTS: 'IMPLEMENTS';
+
+IN: 'IN';
+
+INPUT: 'INPUT';
+
+IS: 'IS';
+
+INTEGER: 'INTEGER';
+
+KILL: 'KILL';
+
+LOAD: 'LOAD';
+
+LOCK: 'LOCK';
+
+LONG: 'LONG';
+
+LOOP: 'LOOP';
+
+LEN: 'LEN';
+
+LET: 'LET';
+
+LIB: 'LIB';
+
+LIKE: 'LIKE';
+
+LINE_INPUT: 'LINE INPUT';
+
+LOCK_READ: 'LOCK READ';
+
+LOCK_WRITE: 'LOCK WRITE';
+
+LOCK_READ_WRITE: 'LOCK READ WRITE';
+
+LSET: 'LSET';
+
+MACRO_IF: HASH 'IF';
+
+MACRO_ELSEIF: HASH 'ELSEIF';
+
+MACRO_ELSE: HASH 'ELSE';
+
+MACRO_END_IF: HASH 'END IF';
+
+ME: 'ME';
+
+MID: 'MID';
+
+MKDIR: 'MKDIR';
+
+MOD: 'MOD';
+
+NAME: 'NAME';
+
+NEXT: 'NEXT';
+
+NEW: 'NEW';
+
+NOT: 'NOT';
+
+NOTHING: 'NOTHING';
+
+NULL_: 'NULL';
+
+OBJECT: 'OBJECT';
+
+ON: 'ON';
+
+ON_ERROR: 'ON ERROR';
+
+ON_LOCAL_ERROR: 'ON LOCAL ERROR';
+
+OPEN: 'OPEN';
+
+OPTIONAL: 'OPTIONAL';
+
+OPTION_BASE: 'OPTION BASE';
+
+OPTION_EXPLICIT: 'OPTION EXPLICIT';
+
+OPTION_COMPARE: 'OPTION COMPARE';
+
+OPTION_PRIVATE_MODULE: 'OPTION PRIVATE MODULE';
+
+OR: 'OR';
+
+OUTPUT: 'OUTPUT';
+
+PARAMARRAY: 'PARAMARRAY';
+
+PRESERVE: 'PRESERVE';
+
+PRINT: 'PRINT';
+
+PRIVATE: 'PRIVATE';
+
+PROPERTY_GET: 'PROPERTY GET';
+
+PROPERTY_LET: 'PROPERTY LET';
+
+PROPERTY_SET: 'PROPERTY SET';
+
+PUBLIC: 'PUBLIC';
+
+PUT: 'PUT';
+
+RANDOM: 'RANDOM';
+
+RANDOMIZE: 'RANDOMIZE';
+
+RAISEEVENT: 'RAISEEVENT';
+
+READ: 'READ';
+
+READ_WRITE: 'READ WRITE';
+
+REDIM: 'REDIM';
+
+REM: 'REM';
+
+RESET: 'RESET';
+
+RESUME: 'RESUME';
+
+RETURN: 'RETURN';
+
+RMDIR: 'RMDIR';
+
+RSET: 'RSET';
+
+SAVEPICTURE: 'SAVEPICTURE';
+
+SAVESETTING: 'SAVESETTING';
+
+SEEK: 'SEEK';
+
+SELECT: 'SELECT';
+
+SENDKEYS: 'SENDKEYS';
+
+SET: 'SET';
+
+SETATTR: 'SETATTR';
+
+SHARED: 'SHARED';
+
+SINGLE: 'SINGLE';
+
+SPC: 'SPC';
+
+STATIC: 'STATIC';
+
+STEP: 'STEP';
+
+STOP: 'STOP';
+
+STRING: 'STRING';
+
+SUB: 'SUB';
+
+TAB: 'TAB';
+
+TEXT: 'TEXT';
+
+THEN: 'THEN';
+
+TIME: 'TIME';
+
+TO: 'TO';
+
+TRUE: 'TRUE';
+
+TYPE: 'TYPE';
+
+TYPEOF: 'TYPEOF';
+
+UNLOAD: 'UNLOAD';
+
+UNLOCK: 'UNLOCK';
+
+UNTIL: 'UNTIL';
+
+VARIANT: 'VARIANT';
+
+VERSION: 'VERSION';
+
+WEND: 'WEND';
+
+WHILE: 'WHILE';
+
+WIDTH: 'WIDTH';
+
+WITH: 'WITH';
+
+WITHEVENTS: 'WITHEVENTS';
+
+WRITE: 'WRITE';
+
+XOR: 'XOR';
+
+// symbols
+
+AMPERSAND: '&';
+
+ASSIGN: ':=';
+
+AT: '@';
+
+COLON: ':';
+
+COMMA: ',';
+
+IDIV : '\\';
+DIV  : '/';
+
+DOLLAR: '$';
+
+DOT: '.';
+
+EQ: '=';
+
+EXCLAMATIONMARK: '!';
+
+GEQ: '>=';
+
+GT: '>';
+
+HASH: '#';
+
+LEQ: '<=';
+
+LBRACE: '{';
+
+LPAREN: '(';
+
+LT: '<';
+
+MINUS: '-';
+
+MINUS_EQ: '-=';
+
+MULT: '*';
+
+NEQ: '<>';
+
+PERCENT: '%';
+
+PLUS: '+';
+
+PLUS_EQ: '+=';
+
+POW: '^';
+
+RBRACE: '}';
+
+RPAREN: ')';
+
+SEMICOLON: ';';
+
+L_SQUARE_BRACKET: '[';
+
+R_SQUARE_BRACKET: ']';
+
+// literals
+
+STRINGLITERAL: '"' (~ ["\r\n] | '""')* '"';
+
+DATELITERAL: HASH (~ [#\r\n])* HASH;
+
+COLORLITERAL: '&H' [0-9A-F]+ AMPERSAND?;
+
+INTEGERLITERAL: [0-9]+ ('E' INTEGERLITERAL)* ( HASH | AMPERSAND | EXCLAMATIONMARK | AT)?;
+
+DOUBLELITERAL:
+    [0-9]* DOT [0-9]+ ('E' (PLUS | MINUS)? [0-9]+)* (HASH | AMPERSAND | EXCLAMATIONMARK | AT)?
+;
+
+FILENUMBER: HASH LETTERORDIGIT+;
+
+OCTALLITERAL: '&O' [0-7]+ AMPERSAND?;
+
+// misc
+FRX_OFFSET: COLON [0-9A-F]+;
+
+GUID: LBRACE [0-9A-F]+ MINUS [0-9A-F]+ MINUS [0-9A-F]+ MINUS [0-9A-F]+ MINUS [0-9A-F]+ RBRACE;
+
+// identifier
+
+IDENTIFIER: LETTER LETTERORDIGIT*;
+
+// whitespace, line breaks, comments, ...
+
+LINE_CONTINUATION: ' ' '_' '\r'? '\n' -> skip;
+
+NEWLINE: WS? ('\r'? '\n' | COLON ' ') WS?;
+
+COMMENT: WS? ('\'' | COLON? REM ' ') ( LINE_CONTINUATION | ~ ('\n' | '\r'))* -> skip;
+
+WS: [ \t]+;
+
+// letters
+
+fragment LETTER: [A-Z_ÄÖÜÁÉÍÓÚÂÊÎÔÛÀÈÌÒÙÃẼĨÕŨÇ];
+
+fragment LETTERORDIGIT: [A-Z0-9_ÄÖÜÁÉÍÓÚÂÊÎÔÛÀÈÌÒÙÃẼĨÕŨÇ];

--- a/antlr-kotlin-tests/antlr/VisualBasic6Parser.g4
+++ b/antlr-kotlin-tests/antlr/VisualBasic6Parser.g4
@@ -1,0 +1,1030 @@
+/*
+ * Copyright (C) 2017, Ulrich Wolffgang <ulrich.wolffgang@proleap.io> All rights reserved.
+ *
+ * This software may be modified and distributed under the terms of the MIT license. See the LICENSE
+ * file for details.
+ */
+
+/*
+ * Visual Basic 6.0 Grammar for ANTLR4
+ *
+ * This is a Visual Basic 6.0 grammar, which is part of the Visual Basic 6.0 parser at
+ * https://github.com/uwol/vb6parser.
+ *
+ * The grammar is derived from the Visual Basic 6.0 language reference
+ * http://msdn.microsoft.com/en-us/library/aa338033%28v=vs.60%29.aspx and has been tested with MSDN
+ * VB6 statements as well as several Visual Basic 6.0 code repositories.
+ */
+
+// $antlr-format alignTrailingComments true, columnLimit 150, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments false, useTab false
+// $antlr-format allowShortRulesOnASingleLine false, allowShortBlocksOnASingleLine true, alignSemicolons hanging, alignColons hanging
+
+parser grammar VisualBasic6Parser;
+
+options {
+    tokenVocab = VisualBasic6Lexer;
+}
+
+// module ----------------------------------
+
+startRule
+    : module EOF
+    ;
+
+module
+    : WS? NEWLINE* (moduleHeader NEWLINE+)? moduleReferences? NEWLINE* controlProperties? NEWLINE* moduleConfig? NEWLINE* moduleAttributes? NEWLINE*
+        moduleOptions? NEWLINE* moduleBody? NEWLINE* WS?
+    ;
+
+moduleReferences
+    : moduleReference+
+    ;
+
+moduleReference
+    : OBJECT WS? EQ WS? moduleReferenceValue (SEMICOLON WS? moduleReferenceComponent)? NEWLINE*
+    ;
+
+moduleReferenceValue
+    : STRINGLITERAL
+    ;
+
+moduleReferenceComponent
+    : STRINGLITERAL
+    ;
+
+moduleHeader
+    : VERSION WS doubleLiteral (WS CLASS)?
+    ;
+
+moduleConfig
+    : BEGIN NEWLINE+ moduleConfigElement+ END NEWLINE+
+    ;
+
+moduleConfigElement
+    : ambiguousIdentifier WS? EQ WS? literal NEWLINE
+    ;
+
+moduleAttributes
+    : (attributeStmt NEWLINE+)+
+    ;
+
+moduleOptions
+    : (moduleOption NEWLINE+)+
+    ;
+
+moduleOption
+    : OPTION_BASE WS integerLiteral     # optionBaseStmt
+    | OPTION_COMPARE WS (BINARY | TEXT) # optionCompareStmt
+    | OPTION_EXPLICIT                   # optionExplicitStmt
+    | OPTION_PRIVATE_MODULE             # optionPrivateModuleStmt
+    ;
+
+moduleBody
+    : moduleBodyElement (NEWLINE+ moduleBodyElement)*
+    ;
+
+moduleBodyElement
+    : moduleBlock
+    | moduleOption
+    | declareStmt
+    | enumerationStmt
+    | eventStmt
+    | functionStmt
+    | macroIfThenElseStmt
+    | propertyGetStmt
+    | propertySetStmt
+    | propertyLetStmt
+    | subStmt
+    | typeStmt
+    ;
+
+// controls ----------------------------------
+
+controlProperties
+    : WS? BEGIN WS cp_ControlType WS cp_ControlIdentifier WS? NEWLINE+ cp_Properties+ END NEWLINE*
+    ;
+
+cp_Properties
+    : cp_SingleProperty
+    | cp_NestedProperty
+    | controlProperties
+    ;
+
+cp_SingleProperty
+    : WS? implicitCallStmt_InStmt WS? EQ WS? '$'? cp_PropertyValue FRX_OFFSET? NEWLINE+
+    ;
+
+cp_PropertyName
+    : (OBJECT DOT)? ambiguousIdentifier (LPAREN literal RPAREN)? (
+        DOT ambiguousIdentifier (LPAREN literal RPAREN)?
+    )*
+    ;
+
+cp_PropertyValue
+    : DOLLAR? (literal | (LBRACE ambiguousIdentifier RBRACE) | POW ambiguousIdentifier)
+    ;
+
+cp_NestedProperty
+    : WS? BEGINPROPERTY WS ambiguousIdentifier (LPAREN integerLiteral RPAREN)? (WS GUID)? NEWLINE+ (
+        cp_Properties+
+    )? ENDPROPERTY NEWLINE+
+    ;
+
+cp_ControlType
+    : complexType
+    ;
+
+cp_ControlIdentifier
+    : ambiguousIdentifier
+    ;
+
+// block ----------------------------------
+
+moduleBlock
+    : block
+    ;
+
+attributeStmt
+    : ATTRIBUTE WS implicitCallStmt_InStmt WS? EQ WS? literal (WS? COMMA WS? literal)*
+    ;
+
+block
+    : blockStmt (NEWLINE+ WS? blockStmt)*
+    ;
+
+blockStmt
+    : appActivateStmt
+    | attributeStmt
+    | beepStmt
+    | chDirStmt
+    | chDriveStmt
+    | closeStmt
+    | constStmt
+    | dateStmt
+    | deleteSettingStmt
+    | deftypeStmt
+    | doLoopStmt
+    | endStmt
+    | eraseStmt
+    | errorStmt
+    | exitStmt
+    | explicitCallStmt
+    | filecopyStmt
+    | forEachStmt
+    | forNextStmt
+    | getStmt
+    | goSubStmt
+    | goToStmt
+    | ifThenElseStmt
+    | implementsStmt
+    | inputStmt
+    | killStmt
+    | letStmt
+    | lineInputStmt
+    | lineLabel
+    | loadStmt
+    | lockStmt
+    | lsetStmt
+    | macroIfThenElseStmt
+    | midStmt
+    | mkdirStmt
+    | nameStmt
+    | onErrorStmt
+    | onGoToStmt
+    | onGoSubStmt
+    | openStmt
+    | printStmt
+    | putStmt
+    | raiseEventStmt
+    | randomizeStmt
+    | redimStmt
+    | resetStmt
+    | resumeStmt
+    | returnStmt
+    | rmdirStmt
+    | rsetStmt
+    | savepictureStmt
+    | saveSettingStmt
+    | seekStmt
+    | selectCaseStmt
+    | sendkeysStmt
+    | setattrStmt
+    | setStmt
+    | stopStmt
+    | timeStmt
+    | unloadStmt
+    | unlockStmt
+    | variableStmt
+    | whileWendStmt
+    | widthStmt
+    | withStmt
+    | writeStmt
+    | implicitCallStmt_InBlock
+    ;
+
+// statements ----------------------------------
+
+appActivateStmt
+    : APPACTIVATE WS valueStmt (WS? COMMA WS? valueStmt)?
+    ;
+
+beepStmt
+    : BEEP
+    ;
+
+chDirStmt
+    : CHDIR WS valueStmt
+    ;
+
+chDriveStmt
+    : CHDRIVE WS valueStmt
+    ;
+
+closeStmt
+    : CLOSE (WS valueStmt (WS? COMMA WS? valueStmt)*)?
+    ;
+
+constStmt
+    : (publicPrivateGlobalVisibility WS)? CONST WS constSubStmt (WS? COMMA WS? constSubStmt)*
+    ;
+
+constSubStmt
+    : ambiguousIdentifier typeHint? (WS asTypeClause)? WS? EQ WS? valueStmt
+    ;
+
+dateStmt
+    : DATE WS? EQ WS? valueStmt
+    ;
+
+declareStmt
+    : (visibility WS)? DECLARE WS (FUNCTION typeHint? | SUB) WS ambiguousIdentifier typeHint? WS LIB WS STRINGLITERAL (
+        WS ALIAS WS STRINGLITERAL
+    )? (WS? argList)? (WS asTypeClause)?
+    ;
+
+deftypeStmt
+    : (
+        DEFBOOL
+        | DEFBYTE
+        | DEFINT
+        | DEFLNG
+        | DEFCUR
+        | DEFSNG
+        | DEFDBL
+        | DEFDEC
+        | DEFDATE
+        | DEFSTR
+        | DEFOBJ
+        | DEFVAR
+    ) WS letterrange (WS? COMMA WS? letterrange)*
+    ;
+
+deleteSettingStmt
+    : DELETESETTING WS valueStmt WS? COMMA WS? valueStmt (WS? COMMA WS? valueStmt)?
+    ;
+
+doLoopStmt
+    : DO NEWLINE+ (block NEWLINE+)? LOOP
+    | DO WS (WHILE | UNTIL) WS valueStmt NEWLINE+ ( block NEWLINE+)? LOOP
+    | DO NEWLINE+ (block NEWLINE+) LOOP WS (WHILE | UNTIL) WS valueStmt
+    ;
+
+endStmt
+    : END
+    ;
+
+enumerationStmt
+    : (publicPrivateVisibility WS)? ENUM WS ambiguousIdentifier NEWLINE+ (enumerationStmt_Constant)* END_ENUM
+    ;
+
+enumerationStmt_Constant
+    : ambiguousIdentifier (WS? EQ WS? valueStmt)? NEWLINE+
+    ;
+
+eraseStmt
+    : ERASE WS valueStmt (WS? COMMA WS? valueStmt)*
+    ;
+
+errorStmt
+    : ERROR WS valueStmt
+    ;
+
+eventStmt
+    : (visibility WS)? EVENT WS ambiguousIdentifier WS? argList
+    ;
+
+exitStmt
+    : EXIT_DO
+    | EXIT_FOR
+    | EXIT_FUNCTION
+    | EXIT_PROPERTY
+    | EXIT_SUB
+    ;
+
+filecopyStmt
+    : FILECOPY WS valueStmt WS? COMMA WS? valueStmt
+    ;
+
+forEachStmt
+    : FOR WS EACH WS ambiguousIdentifier typeHint? WS IN WS valueStmt NEWLINE+ (block NEWLINE+)? NEXT (
+        WS ambiguousIdentifier
+    )?
+    ;
+
+forNextStmt
+    : FOR WS iCS_S_VariableOrProcedureCall typeHint? (WS asTypeClause)? WS? EQ WS? valueStmt WS TO WS valueStmt (
+        WS STEP WS valueStmt
+    )? NEWLINE+ (block NEWLINE+)? NEXT (WS ambiguousIdentifier typeHint?)?
+    ;
+
+functionStmt
+    : (visibility WS)? (STATIC WS)? FUNCTION WS ambiguousIdentifier (WS? argList)? (
+        WS asTypeClause
+    )? NEWLINE+ (block NEWLINE+)? END_FUNCTION
+    ;
+
+getStmt
+    : GET WS valueStmt WS? COMMA WS? valueStmt? WS? COMMA WS? valueStmt
+    ;
+
+goSubStmt
+    : GOSUB WS valueStmt
+    ;
+
+goToStmt
+    : GOTO WS valueStmt
+    ;
+
+ifThenElseStmt
+    : IF WS ifConditionStmt WS THEN WS blockStmt (WS ELSE WS blockStmt)? # inlineIfThenElse
+    | ifBlockStmt ifElseIfBlockStmt* ifElseBlockStmt? END_IF             # blockIfThenElse
+    ;
+
+ifBlockStmt
+    : IF WS ifConditionStmt WS THEN NEWLINE+ (block NEWLINE+)?
+    ;
+
+ifConditionStmt
+    : valueStmt
+    ;
+
+ifElseIfBlockStmt
+    : ELSEIF WS ifConditionStmt WS THEN NEWLINE+ (block NEWLINE+)?
+    ;
+
+ifElseBlockStmt
+    : ELSE NEWLINE+ (block NEWLINE+)?
+    ;
+
+implementsStmt
+    : IMPLEMENTS WS ambiguousIdentifier
+    ;
+
+inputStmt
+    : INPUT WS valueStmt (WS? COMMA WS? valueStmt)+
+    ;
+
+killStmt
+    : KILL WS valueStmt
+    ;
+
+letStmt
+    : (LET WS)? implicitCallStmt_InStmt WS? (EQ | PLUS_EQ | MINUS_EQ) WS? valueStmt
+    ;
+
+lineInputStmt
+    : LINE_INPUT WS valueStmt WS? COMMA WS? valueStmt
+    ;
+
+loadStmt
+    : LOAD WS valueStmt
+    ;
+
+lockStmt
+    : LOCK WS valueStmt (WS? COMMA WS? valueStmt (WS TO WS valueStmt)?)?
+    ;
+
+lsetStmt
+    : LSET WS implicitCallStmt_InStmt WS? EQ WS? valueStmt
+    ;
+
+macroIfThenElseStmt
+    : macroIfBlockStmt macroElseIfBlockStmt* macroElseBlockStmt? MACRO_END_IF
+    ;
+
+macroIfBlockStmt
+    : MACRO_IF WS ifConditionStmt WS THEN NEWLINE+ (moduleBody NEWLINE+)?
+    ;
+
+macroElseIfBlockStmt
+    : MACRO_ELSEIF WS ifConditionStmt WS THEN NEWLINE+ (moduleBody NEWLINE+)?
+    ;
+
+macroElseBlockStmt
+    : MACRO_ELSE NEWLINE+ (moduleBody NEWLINE+)?
+    ;
+
+midStmt
+    : MID WS? LPAREN WS? argsCall WS? RPAREN
+    ;
+
+mkdirStmt
+    : MKDIR WS valueStmt
+    ;
+
+nameStmt
+    : NAME WS valueStmt WS AS WS valueStmt
+    ;
+
+onErrorStmt
+    : (ON_ERROR | ON_LOCAL_ERROR) WS (GOTO WS valueStmt COLON? | RESUME WS NEXT)
+    ;
+
+onGoToStmt
+    : ON WS valueStmt WS GOTO WS valueStmt (WS? COMMA WS? valueStmt)*
+    ;
+
+onGoSubStmt
+    : ON WS valueStmt WS GOSUB WS valueStmt (WS? COMMA WS? valueStmt)*
+    ;
+
+openStmt
+    : OPEN WS valueStmt WS FOR WS (APPEND | BINARY | INPUT | OUTPUT | RANDOM) (
+        WS ACCESS WS (READ | WRITE | READ_WRITE)
+    )? (WS (SHARED | LOCK_READ | LOCK_WRITE | LOCK_READ_WRITE))? WS AS WS valueStmt (
+        WS LEN WS? EQ WS? valueStmt
+    )?
+    ;
+
+outputList
+    : outputList_Expression (WS? (SEMICOLON | COMMA) WS? outputList_Expression?)*
+    | outputList_Expression? (WS? (SEMICOLON | COMMA) WS? outputList_Expression?)+
+    ;
+
+outputList_Expression
+    : (SPC | TAB) (WS? LPAREN WS? argsCall WS? RPAREN)?
+    | valueStmt
+    ;
+
+printStmt
+    : PRINT WS valueStmt WS? COMMA (WS? outputList)?
+    ;
+
+propertyGetStmt
+    : (visibility WS)? (STATIC WS)? PROPERTY_GET WS ambiguousIdentifier typeHint? (WS? argList)? (
+        WS asTypeClause
+    )? NEWLINE+ (block NEWLINE+)? END_PROPERTY
+    ;
+
+propertySetStmt
+    : (visibility WS)? (STATIC WS)? PROPERTY_SET WS ambiguousIdentifier (WS? argList)? NEWLINE+ (
+        block NEWLINE+
+    )? END_PROPERTY
+    ;
+
+propertyLetStmt
+    : (visibility WS)? (STATIC WS)? PROPERTY_LET WS ambiguousIdentifier (WS? argList)? NEWLINE+ (
+        block NEWLINE+
+    )? END_PROPERTY
+    ;
+
+putStmt
+    : PUT WS valueStmt WS? COMMA WS? valueStmt? WS? COMMA WS? valueStmt
+    ;
+
+raiseEventStmt
+    : RAISEEVENT WS ambiguousIdentifier (WS? LPAREN WS? (argsCall WS?)? RPAREN)?
+    ;
+
+randomizeStmt
+    : RANDOMIZE (WS valueStmt)?
+    ;
+
+redimStmt
+    : REDIM WS (PRESERVE WS)? redimSubStmt (WS? COMMA WS? redimSubStmt)*
+    ;
+
+redimSubStmt
+    : implicitCallStmt_InStmt WS? LPAREN WS? subscripts WS? RPAREN (WS asTypeClause)?
+    ;
+
+resetStmt
+    : RESET
+    ;
+
+resumeStmt
+    : RESUME (WS (NEXT | ambiguousIdentifier))?
+    ;
+
+returnStmt
+    : RETURN
+    ;
+
+rmdirStmt
+    : RMDIR WS valueStmt
+    ;
+
+rsetStmt
+    : RSET WS implicitCallStmt_InStmt WS? EQ WS? valueStmt
+    ;
+
+savepictureStmt
+    : SAVEPICTURE WS valueStmt WS? COMMA WS? valueStmt
+    ;
+
+saveSettingStmt
+    : SAVESETTING WS valueStmt WS? COMMA WS? valueStmt WS? COMMA WS? valueStmt WS? COMMA WS? valueStmt
+    ;
+
+seekStmt
+    : SEEK WS valueStmt WS? COMMA WS? valueStmt
+    ;
+
+selectCaseStmt
+    : SELECT WS CASE WS valueStmt NEWLINE+ sC_Case* WS? END_SELECT
+    ;
+
+sC_Case
+    : CASE WS sC_Cond WS? (COLON? NEWLINE* | NEWLINE+) (block NEWLINE+)?
+    ;
+
+// ELSE first, so that it is not interpreted as a variable call
+sC_Cond
+    : ELSE                                     # caseCondElse
+    | sC_CondExpr (WS? COMMA WS? sC_CondExpr)* # caseCondExpr
+    ;
+
+sC_CondExpr
+    : IS WS? comparisonOperator WS? valueStmt # caseCondExprIs
+    | valueStmt                               # caseCondExprValue
+    | valueStmt WS TO WS valueStmt            # caseCondExprTo
+    ;
+
+sendkeysStmt
+    : SENDKEYS WS valueStmt (WS? COMMA WS? valueStmt)?
+    ;
+
+setattrStmt
+    : SETATTR WS valueStmt WS? COMMA WS? valueStmt
+    ;
+
+setStmt
+    : SET WS implicitCallStmt_InStmt WS? EQ WS? valueStmt
+    ;
+
+stopStmt
+    : STOP
+    ;
+
+subStmt
+    : (visibility WS)? (STATIC WS)? SUB WS ambiguousIdentifier (WS? argList)? NEWLINE+ (
+        block NEWLINE+
+    )? END_SUB
+    ;
+
+timeStmt
+    : TIME WS? EQ WS? valueStmt
+    ;
+
+typeStmt
+    : (visibility WS)? TYPE WS ambiguousIdentifier NEWLINE+ (typeStmt_Element)* END_TYPE
+    ;
+
+typeStmt_Element
+    : ambiguousIdentifier (WS? LPAREN (WS? subscripts)? WS? RPAREN)? (WS asTypeClause)? NEWLINE+
+    ;
+
+typeOfStmt
+    : TYPEOF WS valueStmt (WS IS WS type_)?
+    ;
+
+unloadStmt
+    : UNLOAD WS valueStmt
+    ;
+
+unlockStmt
+    : UNLOCK WS valueStmt (WS? COMMA WS? valueStmt (WS TO WS valueStmt)?)?
+    ;
+
+// operator precedence is represented by rule order
+valueStmt
+    : literal                                                                  # vsLiteral
+    | LPAREN WS? valueStmt (WS? COMMA WS? valueStmt)* WS? RPAREN               # vsStruct
+    | NEW WS valueStmt                                                         # vsNew
+    | typeOfStmt                                                               # vsTypeOf
+    | ADDRESSOF WS valueStmt                                                   # vsAddressOf
+    | implicitCallStmt_InStmt WS? ASSIGN WS? valueStmt                         # vsAssign
+    | valueStmt WS? POW WS? valueStmt                                          # vsPow
+    | (PLUS | MINUS) WS? valueStmt                                             # vsPlusMinus
+    | valueStmt WS? (MULT | DIV) WS? valueStmt                                 # vsMultDiv
+    | valueStmt WS? (IDIV) WS? valueStmt                                       # vsIDiv
+    | valueStmt WS? MOD WS? valueStmt                                          # vsMod
+    | valueStmt WS? (PLUS | MINUS) WS? valueStmt                               # vsAddSub
+    | valueStmt WS? AMPERSAND WS? valueStmt                                    # vsAmp
+    | valueStmt WS? (EQ | NEQ | LT | GT | LEQ | GEQ | LIKE | IS) WS? valueStmt # vsComp
+    | NOT (WS valueStmt | LPAREN WS? valueStmt WS? RPAREN)                     # vsNot
+    | valueStmt WS? AND WS? valueStmt                                          # vsAnd
+    | valueStmt WS? OR WS? valueStmt                                           # vsOr
+    | valueStmt WS? XOR WS? valueStmt                                          # vsXor
+    | valueStmt WS? EQV WS? valueStmt                                          # vsEqv
+    | valueStmt WS? IMP WS? valueStmt                                          # vsImp
+    | implicitCallStmt_InStmt                                                  # vsICS
+    | midStmt                                                                  # vsMid
+    ;
+
+variableStmt
+    : (DIM | STATIC | visibility) WS (WITHEVENTS WS)? variableListStmt
+    ;
+
+variableListStmt
+    : variableSubStmt (WS? COMMA WS? variableSubStmt)*
+    ;
+
+variableSubStmt
+    : ambiguousIdentifier typeHint? (WS? LPAREN WS? (subscripts WS?)? RPAREN WS?)? (
+        WS asTypeClause
+    )?
+    ;
+
+whileWendStmt
+    : WHILE WS valueStmt NEWLINE+ block* NEWLINE* WEND
+    ;
+
+widthStmt
+    : WIDTH WS valueStmt WS? COMMA WS? valueStmt
+    ;
+
+withStmt
+    : WITH WS (NEW WS)? implicitCallStmt_InStmt NEWLINE+ (block NEWLINE+)? END_WITH
+    ;
+
+writeStmt
+    : WRITE WS valueStmt WS? COMMA (WS? outputList)?
+    ;
+
+// complex call statements ----------------------------------
+
+explicitCallStmt
+    : eCS_ProcedureCall
+    | eCS_MemberProcedureCall
+    ;
+
+// parantheses are required in case of args -> empty parantheses are removed
+eCS_ProcedureCall
+    : CALL WS ambiguousIdentifier typeHint? (WS? LPAREN WS? argsCall WS? RPAREN)?
+    ;
+
+// parantheses are required in case of args -> empty parantheses are removed
+eCS_MemberProcedureCall
+    : CALL WS implicitCallStmt_InStmt? DOT WS? ambiguousIdentifier typeHint? (
+        WS? LPAREN WS? argsCall WS? RPAREN
+    )?
+    ;
+
+implicitCallStmt_InBlock
+    : iCS_B_ProcedureCall
+    | iCS_B_MemberProcedureCall
+    ;
+
+// parantheses are forbidden in case of args variables cannot be called in blocks certainIdentifier
+// instead of ambiguousIdentifier for preventing ambiguity with statement keywords
+iCS_B_ProcedureCall
+    : certainIdentifier (WS argsCall)?
+    ;
+
+iCS_B_MemberProcedureCall
+    : implicitCallStmt_InStmt? DOT ambiguousIdentifier typeHint? (WS argsCall)? dictionaryCallStmt?
+    ;
+
+// iCS_S_MembersCall first, so that member calls are not resolved as separate iCS_S_VariableOrProcedureCalls
+implicitCallStmt_InStmt
+    : iCS_S_MembersCall
+    | iCS_S_VariableOrProcedureCall
+    | iCS_S_ProcedureOrArrayCall
+    | iCS_S_DictionaryCall
+    ;
+
+iCS_S_VariableOrProcedureCall
+    : ambiguousIdentifier typeHint? dictionaryCallStmt?
+    ;
+
+iCS_S_ProcedureOrArrayCall
+    : (ambiguousIdentifier | baseType | iCS_S_NestedProcedureCall) typeHint? WS? (
+        LPAREN WS? (argsCall WS?)? RPAREN
+    )+ dictionaryCallStmt?
+    ;
+
+iCS_S_NestedProcedureCall
+    : ambiguousIdentifier typeHint? WS? LPAREN WS? (argsCall WS?)? RPAREN
+    ;
+
+iCS_S_MembersCall
+    : (iCS_S_VariableOrProcedureCall | iCS_S_ProcedureOrArrayCall)? iCS_S_MemberCall+ dictionaryCallStmt?
+    ;
+
+iCS_S_MemberCall
+    : WS? DOT (iCS_S_VariableOrProcedureCall | iCS_S_ProcedureOrArrayCall)
+    ;
+
+iCS_S_DictionaryCall
+    : dictionaryCallStmt
+    ;
+
+// atomic call statements ----------------------------------
+
+argsCall
+    : (argCall? WS? (COMMA | SEMICOLON) WS?)* argCall (WS? (COMMA | SEMICOLON) WS? argCall?)*
+    ;
+
+argCall
+    : ((BYVAL | BYREF | PARAMARRAY) WS)? valueStmt
+    ;
+
+dictionaryCallStmt
+    : EXCLAMATIONMARK ambiguousIdentifier typeHint?
+    ;
+
+// atomic rules for statements
+argList
+    : LPAREN (WS? arg (WS? COMMA WS? arg)*)? WS? RPAREN
+    ;
+
+arg
+    : (OPTIONAL WS)? ((BYVAL | BYREF) WS)? (PARAMARRAY WS)? ambiguousIdentifier typeHint? (
+        WS? LPAREN WS? RPAREN
+    )? (WS asTypeClause)? (WS? argDefaultValue)?
+    ;
+
+argDefaultValue
+    : EQ WS? valueStmt
+    ;
+
+subscripts
+    : subscript_ (WS? COMMA WS? subscript_)*
+    ;
+
+subscript_
+    : (valueStmt WS TO WS)? valueStmt
+    ;
+
+// atomic rules ----------------------------------
+
+ambiguousIdentifier
+    : (IDENTIFIER | ambiguousKeyword)+
+    | L_SQUARE_BRACKET (IDENTIFIER | ambiguousKeyword)+ R_SQUARE_BRACKET
+    ;
+
+asTypeClause
+    : AS WS (NEW WS)? type_ (WS fieldLength)?
+    ;
+
+baseType
+    : BOOLEAN
+    | BYTE
+    | COLLECTION
+    | DATE
+    | DOUBLE
+    | INTEGER
+    | LONG
+    | OBJECT
+    | SINGLE
+    | STRING
+    | VARIANT
+    ;
+
+certainIdentifier
+    : IDENTIFIER (ambiguousKeyword | IDENTIFIER)*
+    | ambiguousKeyword (ambiguousKeyword | IDENTIFIER)+
+    ;
+
+comparisonOperator
+    : LT
+    | LEQ
+    | GT
+    | GEQ
+    | EQ
+    | NEQ
+    | IS
+    | LIKE
+    ;
+
+complexType
+    : ambiguousIdentifier (DOT ambiguousIdentifier)*
+    ;
+
+fieldLength
+    : MULT WS? (integerLiteral | ambiguousIdentifier)
+    ;
+
+letterrange
+    : certainIdentifier (WS? MINUS WS? certainIdentifier)?
+    ;
+
+lineLabel
+    : ambiguousIdentifier COLON
+    ;
+
+literal
+    : COLORLITERAL
+    | DATELITERAL
+    | doubleLiteral
+    | FILENUMBER
+    | integerLiteral
+    | octalLiteral
+    | STRINGLITERAL
+    | TRUE
+    | FALSE
+    | NOTHING
+    | NULL_
+    ;
+
+publicPrivateVisibility
+    : PRIVATE
+    | PUBLIC
+    ;
+
+publicPrivateGlobalVisibility
+    : PRIVATE
+    | PUBLIC
+    | GLOBAL
+    ;
+
+type_
+    : (baseType | complexType) (WS? LPAREN WS? RPAREN)?
+    ;
+
+typeHint
+    : AMPERSAND
+    | AT
+    | DOLLAR
+    | EXCLAMATIONMARK
+    | HASH
+    | PERCENT
+    ;
+
+visibility
+    : PRIVATE
+    | PUBLIC
+    | FRIEND
+    | GLOBAL
+    ;
+
+// ambiguous keywords
+ambiguousKeyword
+    : ACCESS
+    | ADDRESSOF
+    | ALIAS
+    | AND
+    | ATTRIBUTE
+    | APPACTIVATE
+    | APPEND
+    | AS
+    | BEEP
+    | BEGIN
+    | BINARY
+    | BOOLEAN
+    | BYVAL
+    | BYREF
+    | BYTE
+    | CALL
+    | CASE
+    | CLASS
+    | CLOSE
+    | CHDIR
+    | CHDRIVE
+    | COLLECTION
+    | CONST
+    | DATE
+    | DECLARE
+    | DEFBOOL
+    | DEFBYTE
+    | DEFCUR
+    | DEFDBL
+    | DEFDATE
+    | DEFDEC
+    | DEFINT
+    | DEFLNG
+    | DEFOBJ
+    | DEFSNG
+    | DEFSTR
+    | DEFVAR
+    | DELETESETTING
+    | DIM
+    | DO
+    | DOUBLE
+    | EACH
+    | ELSE
+    | ELSEIF
+    | END
+    | ENUM
+    | EQV
+    | ERASE
+    | ERROR
+    | EVENT
+    | FALSE
+    | FILECOPY
+    | FRIEND
+    | FOR
+    | FUNCTION
+    | GET
+    | GLOBAL
+    | GOSUB
+    | GOTO
+    | IF
+    | IMP
+    | IMPLEMENTS
+    | IN
+    | INPUT
+    | IS
+    | INTEGER
+    | KILL
+    | LOAD
+    | LOCK
+    | LONG
+    | LOOP
+    | LEN
+    | LET
+    | LIB
+    | LIKE
+    | LSET
+    | ME
+    | MID
+    | MKDIR
+    | MOD
+    | NAME
+    | NEXT
+    | NEW
+    | NOT
+    | NOTHING
+    | NULL_
+    | OBJECT
+    | ON
+    | OPEN
+    | OPTIONAL
+    | OR
+    | OUTPUT
+    | PARAMARRAY
+    | PRESERVE
+    | PRINT
+    | PRIVATE
+    | PUBLIC
+    | PUT
+    | RANDOM
+    | RANDOMIZE
+    | RAISEEVENT
+    | READ
+    | REDIM
+    | REM
+    | RESET
+    | RESUME
+    | RETURN
+    | RMDIR
+    | RSET
+    | SAVEPICTURE
+    | SAVESETTING
+    | SEEK
+    | SELECT
+    | SENDKEYS
+    | SET
+    | SETATTR
+    | SHARED
+    | SINGLE
+    | SPC
+    | STATIC
+    | STEP
+    | STOP
+    | STRING
+    | SUB
+    | TAB
+    | TEXT
+    | THEN
+    | TIME
+    | TO
+    | TRUE
+    | TYPE
+    | TYPEOF
+    | UNLOAD
+    | UNLOCK
+    | UNTIL
+    | VARIANT
+    | VERSION
+    | WEND
+    | WHILE
+    | WIDTH
+    | WITH
+    | WITHEVENTS
+    | WRITE
+    | XOR
+    ;
+
+integerLiteral
+    : (PLUS | MINUS)* INTEGERLITERAL
+    ;
+
+octalLiteral
+    : (PLUS | MINUS)* OCTALLITERAL
+    ;
+
+doubleLiteral
+    : (PLUS | MINUS)* DOUBLELITERAL
+    ;

--- a/antlr-kotlin-tests/build.gradle.kts
+++ b/antlr-kotlin-tests/build.gradle.kts
@@ -68,7 +68,12 @@ tasks {
 
   val generateKotlinGrammarSource = register<AntlrTask>("generateKotlinGrammarSource") {
     dependsOn("cleanGenerateKotlinGrammarSource")
-    setSource(layout.projectDirectory.dir("antlr"))
+
+    // Only include *.g4 files. This allows tools (e.g., IDE plugins)
+    // to generate temporary files inside the base path
+    source = fileTree(layout.projectDirectory.dir("antlr")) {
+      include("**/*.g4")
+    }
 
     val pkgName = "com.strumenta.antlrkotlin.test.generated"
     arguments = listOf(

--- a/antlr-kotlin-tests/src/commonTest/kotlin/com/strumenta/antlrkotlin/test/GrammarTest.kt
+++ b/antlr-kotlin-tests/src/commonTest/kotlin/com/strumenta/antlrkotlin/test/GrammarTest.kt
@@ -5,6 +5,7 @@ import org.antlr.v4.kotlinruntime.*
 import org.antlr.v4.kotlinruntime.tree.Trees
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 /**
  * The base class for implementing grammar tests.
@@ -12,7 +13,18 @@ import kotlin.test.assertEquals
  * @author Edoardo Luppi
  */
 abstract class GrammarTest<L : Lexer, P : Parser> {
-  data class TestRun(val exampleFilePath: String, val treeFilePath: String)
+  private companion object {
+    private const val CHAR_CR = "\r"
+    private const val CHAR_LF = "\n"
+    private const val LITERAL_BACKSLASH_R = "\\\\r"
+    private const val LITERAL_BACKSLASH_N = "\\\\n"
+    private const val LITERAL_BACKSLASH_R_PLACEHOLDER = "literal-backslash-r"
+    private const val LITERAL_BACKSLASH_N_PLACEHOLDER = "literal-backslash-n"
+    private val REGEXP_PLACEHOLDERS = Regex("\\\\r|\\\\n|literal-backslash-r|literal-backslash-n")
+  }
+
+  data class LispTestRun(val exampleFilePath: String, val treeFilePath: String)
+  data class ErrorsTestRun(val exampleFilePath: String, val errorsFilePath: String)
 
   /**
    * Creates and returns the appropriate [Lexer] for this grammar.
@@ -29,31 +41,42 @@ abstract class GrammarTest<L : Lexer, P : Parser> {
    * should be parsed, and to which example LISP trees their
    * LISP representation should be matched against.
    *
-   * A [TestRun] is a pair indicating the example source file to load,
+   * A [LispTestRun] is a pair indicating the example source file to load,
    * and its expected LISP tree representation file.
    */
-  abstract fun setupTreeTestRuns(runs: MutableSet<TestRun>)
+  abstract fun setupTreeTestRuns(runs: MutableSet<LispTestRun>)
 
   /**
-   * Returns the tree's node to use to match the LISP representation.
+   * Sets up syntax errors tests.
+   *
+   * A [ErrorsTestRun] is a pair indicating the example source file to parse,
+   * and the file containing the expected syntax errors (one per line).
+   */
+  abstract fun setupErrorsTestRuns(runs: MutableSet<ErrorsTestRun>)
+
+  /**
+   * Returns the tree's node to use to match the LISP representation
+   * or the outputted syntax errors.
    */
   abstract fun getTree(parser: P): ParserRuleContext
 
   @Test
   open fun matchesLispTree() {
-    val testRuns = LinkedHashSet<TestRun>(32)
+    val testRuns = LinkedHashSet<LispTestRun>(32)
     setupTreeTestRuns(testRuns)
-
-    if (testRuns.isEmpty()) {
-      throw IllegalStateException("Test runs should be at least one")
-    }
-
-    testRuns.forEach(::executeTestRun)
+    testRuns.forEach(::executeLispTestRun)
   }
 
-  private fun executeTestRun(run: TestRun) {
-    val languageSourceText = loadResourceText("src/commonTest/resources/${run.exampleFilePath}")
-    val expectedLispTreeText = loadResourceText("src/commonTest/resources/${run.treeFilePath}")
+  @Test
+  open fun matchesErrors() {
+    val testRuns = LinkedHashSet<ErrorsTestRun>(32)
+    setupErrorsTestRuns(testRuns)
+    testRuns.forEach(::executeErrorsTestRun)
+  }
+
+  private fun executeLispTestRun(testRun: LispTestRun) {
+    val languageSourceText = loadResourceText("src/commonTest/resources/${testRun.exampleFilePath}")
+    val expectedLispTreeText = loadResourceText("src/commonTest/resources/${testRun.treeFilePath}")
 
     // Create the lexer
     val charStream = CharStreams.fromString(languageSourceText)
@@ -74,7 +97,66 @@ abstract class GrammarTest<L : Lexer, P : Parser> {
     assertEquals(
       expected = expectedLispTreeText,
       actual = lispTree,
-      message = "Outputted LISP tree for file '${run.exampleFilePath}' does not match the expected tree",
+      message = "Outputted LISP tree for file '${testRun.exampleFilePath}' does not match the expected tree",
     )
   }
+
+  private fun executeErrorsTestRun(testRun: ErrorsTestRun) {
+    val languageSourceText = loadResourceText("src/commonTest/resources/${testRun.exampleFilePath}")
+    val expectedErrorsText = loadResourceText("src/commonTest/resources/${testRun.errorsFilePath}")
+    val listener = SyntaxErrorsErrorListener()
+
+    // Create the lexer
+    val charStream = CharStreams.fromString(languageSourceText)
+    val lexer = createLexer(charStream)
+    lexer.removeErrorListeners()
+    lexer.addErrorListener(listener)
+
+    // Create the parser
+    val tokenStream = CommonTokenStream(lexer)
+    val parser = createParser(tokenStream)
+    parser.removeErrorListeners()
+    parser.addErrorListener(listener)
+
+    // Parse the document
+    getTree(parser)
+
+    val expectedErrors = expectedErrorsText.lineSequence()
+      .filter(String::isNotBlank)
+      .map(::replacePlaceholders)
+      .toList()
+
+    val actualErrors = listener.errors.asSequence()
+      .map(::replacePlaceholders)
+      .toList()
+
+    assertErrors(
+      expected = expectedErrors,
+      actual = actualErrors,
+      errorsFilePath = testRun.errorsFilePath,
+    )
+  }
+
+  private fun assertErrors(expected: List<String>, actual: List<String>, errorsFilePath: String) {
+    if (expected.size != actual.size) {
+      fail("${errorsFilePath}: expected ${expected.size} errors, but was ${actual.size} errors")
+    }
+
+    for (i in expected.indices) {
+      if (expected[i] != actual[i]) {
+        fail("${errorsFilePath}: expected '${expected[i]}', but was '${actual[i]}'")
+      }
+    }
+  }
+
+  private fun replacePlaceholders(str: String): String =
+    str.replace(REGEXP_PLACEHOLDERS) {
+      when (it.value) {
+        LITERAL_BACKSLASH_R -> CHAR_CR
+        LITERAL_BACKSLASH_N -> CHAR_LF
+        LITERAL_BACKSLASH_R_PLACEHOLDER -> LITERAL_BACKSLASH_R
+        LITERAL_BACKSLASH_N_PLACEHOLDER -> LITERAL_BACKSLASH_N
+        else -> throw IllegalStateException("Should never land here")
+      }
+    }
 }

--- a/antlr-kotlin-tests/src/commonTest/kotlin/com/strumenta/antlrkotlin/test/SyntaxErrorsErrorListener.kt
+++ b/antlr-kotlin-tests/src/commonTest/kotlin/com/strumenta/antlrkotlin/test/SyntaxErrorsErrorListener.kt
@@ -1,0 +1,26 @@
+package com.strumenta.antlrkotlin.test
+
+import org.antlr.v4.kotlinruntime.BaseErrorListener
+import org.antlr.v4.kotlinruntime.RecognitionException
+import org.antlr.v4.kotlinruntime.Recognizer
+
+/**
+ * Accumulates syntax errors while parsing.
+ */
+class SyntaxErrorsErrorListener : BaseErrorListener() {
+  private var errorMessages = ArrayList<String>(16)
+
+  val errors: List<String>
+    get() = errorMessages
+
+  override fun syntaxError(
+    recognizer: Recognizer<*, *>,
+    offendingSymbol: Any?,
+    line: Int,
+    charPositionInLine: Int,
+    msg: String,
+    e: RecognitionException?,
+  ) {
+    errorMessages.add("line $line:$charPositionInLine $msg")
+  }
+}

--- a/antlr-kotlin-tests/src/commonTest/kotlin/com/strumenta/antlrkotlin/test/grammars/CPP14GrammarTest.kt
+++ b/antlr-kotlin-tests/src/commonTest/kotlin/com/strumenta/antlrkotlin/test/grammars/CPP14GrammarTest.kt
@@ -15,9 +15,13 @@ class CPP14GrammarTest : GrammarTest<CPP14Lexer, CPP14Parser>() {
   override fun createParser(input: TokenStream): CPP14Parser =
     CPP14Parser(input)
 
-  override fun setupTreeTestRuns(runs: MutableSet<TestRun>) {
-    runs += TestRun("cpp/test.cpp", "cpp/test.cpp.tree")
-    runs += TestRun("cpp/macro.cpp", "cpp/macro.cpp.tree")
+  override fun setupTreeTestRuns(runs: MutableSet<LispTestRun>) {
+    runs += LispTestRun("cpp/test.cpp", "cpp/test.cpp.tree")
+    runs += LispTestRun("cpp/macro.cpp", "cpp/macro.cpp.tree")
+  }
+
+  override fun setupErrorsTestRuns(runs: MutableSet<ErrorsTestRun>) {
+    // No test runs
   }
 
   override fun getTree(parser: CPP14Parser): ParserRuleContext =

--- a/antlr-kotlin-tests/src/commonTest/kotlin/com/strumenta/antlrkotlin/test/grammars/Css3GrammarTest.kt
+++ b/antlr-kotlin-tests/src/commonTest/kotlin/com/strumenta/antlrkotlin/test/grammars/Css3GrammarTest.kt
@@ -15,8 +15,12 @@ class Css3GrammarTest : GrammarTest<css3Lexer, css3Parser>() {
   override fun createParser(input: TokenStream): css3Parser =
     css3Parser(input)
 
-  override fun setupTreeTestRuns(runs: MutableSet<TestRun>) {
-    runs += TestRun("css3/at-rule.css", "css3/at-rule.css.tree")
+  override fun setupTreeTestRuns(runs: MutableSet<LispTestRun>) {
+    runs += LispTestRun("css3/at-rule.css", "css3/at-rule.css.tree")
+  }
+
+  override fun setupErrorsTestRuns(runs: MutableSet<ErrorsTestRun>) {
+    // No test runs
   }
 
   override fun getTree(parser: css3Parser): ParserRuleContext =

--- a/antlr-kotlin-tests/src/commonTest/kotlin/com/strumenta/antlrkotlin/test/grammars/Vb6GrammarTest.kt
+++ b/antlr-kotlin-tests/src/commonTest/kotlin/com/strumenta/antlrkotlin/test/grammars/Vb6GrammarTest.kt
@@ -1,0 +1,28 @@
+package com.strumenta.antlrkotlin.test.grammars
+
+import com.strumenta.antlrkotlin.test.GrammarTest
+import com.strumenta.antlrkotlin.test.generated.VisualBasic6Lexer
+import com.strumenta.antlrkotlin.test.generated.VisualBasic6Parser
+import org.antlr.v4.kotlinruntime.CharStream
+import org.antlr.v4.kotlinruntime.ParserRuleContext
+import org.antlr.v4.kotlinruntime.TokenStream
+
+@Suppress("unused")
+class Vb6GrammarTest : GrammarTest<VisualBasic6Lexer, VisualBasic6Parser>() {
+  override fun createLexer(input: CharStream): VisualBasic6Lexer =
+    VisualBasic6Lexer(input)
+
+  override fun createParser(input: TokenStream): VisualBasic6Parser =
+    VisualBasic6Parser(input)
+
+  override fun setupTreeTestRuns(runs: MutableSet<LispTestRun>) {
+    // No test runs
+  }
+
+  override fun setupErrorsTestRuns(runs: MutableSet<ErrorsTestRun>) {
+    runs += ErrorsTestRun("vb6/form1.vb", "vb6/form1.vb.errors")
+  }
+
+  override fun getTree(parser: VisualBasic6Parser): ParserRuleContext =
+    parser.startRule()
+}

--- a/antlr-kotlin-tests/src/commonTest/resources/vb6/form1.vb
+++ b/antlr-kotlin-tests/src/commonTest/resources/vb6/form1.vb
@@ -1,0 +1,40 @@
+Public Class Form1
+
+   Private Sub Form1_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+      ' Create two buttons to use as the accept and cancel buttons. 
+      Dim button1 As New Button()
+      Dim button2 As New Button()
+      ' Set the text of button1 to "OK".
+      button1.Text = "OK"
+      ' Set the position of the button on the form.
+      button1.Location = New Point(10, 10)
+      ' Set the text of button2 to "Cancel".
+      button2.Text = "Cancel"
+      ' Set the position of the button based on the location of button1.
+      button2.Location = _
+         New Point(button1.Left, button1.Height + button1.Top + 10)
+      ' Set the caption bar text of the form.   
+      Me.Text = "tutorialspoint.com"
+      ' Display a help button on the form.
+      Me.HelpButton = True
+     ' Define the border style of the form to a dialog box.
+      Me.FormBorderStyle = FormBorderStyle.FixedDialog
+      ' Set the MaximizeBox to false to remove the maximize box.
+      Me.MaximizeBox = False
+      ' Set the MinimizeBox to false to remove the minimize box.
+      Me.MinimizeBox = False
+      ' Set the accept button of the form to button1.
+      Me.AcceptButton = button1
+      ' Set the cancel button of the form to button2.
+      Me.CancelButton = button2
+      ' Set the start position of the form to the center of the screen.
+      Me.StartPosition = FormStartPosition.CenterScreen
+      ' Set window width and height
+      Me.Height = 300
+      Me.Width = 560
+      ' Add button1 to the form.
+      Me.Controls.Add(button1)
+      ' Add button2 to the form.
+      Me.Controls.Add(button2)
+   End Sub
+End Class

--- a/antlr-kotlin-tests/src/commonTest/resources/vb6/form1.vb.errors
+++ b/antlr-kotlin-tests/src/commonTest/resources/vb6/form1.vb.errors
@@ -1,0 +1,1 @@
+line 1:13 mismatched input 'Form1' expecting <EOF>


### PR DESCRIPTION
Trying to support syntax errors testing I ended up using the Visual Basic grammar, which is generated with a segmented serialized ATN. This revealed some issues with segmented ATNs, which are now solved at the template level.

A segmented ATN is now created by using a `StringBuilder` initialized with the correct size, instead of creating a throwaway list to join each element.

```kotlin
private val SERIALIZED_ATN = buildString(65535 / 3 * 2) {
    append(SERIALIZED_ATN_SEGMENT0)
    append(SERIALIZED_ATN_SEGMENT1)
}
```