### PR TITLE
fix: add @ ExperimentalStdlibApi on Enum.entries for kotlin 1.9.x.

### DIFF
--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -961,12 +961,15 @@ public open class <lexer.name>(input: CharStream) : <superClass; null="Lexer">(i
     override val serializedATN: String =
         SERIALIZED_ATN
 
+    @kotlin.ExperimentalStdlibApi
     override val ruleNames: Array\<String> =
         Rules.entries.map(Rules::name).toTypedArray()
 
+    @kotlin.ExperimentalStdlibApi
     override val channelNames: Array\<String> =
         Channels.entries.map(Channels::name).toTypedArray()
 
+    @kotlin.ExperimentalStdlibApi
     override val modeNames: Array\<String> =
         Modes.entries.map(Modes::name).toTypedArray()
 


### PR DESCRIPTION
This should fix issue #136.