### PR TITLE
Revert "fix: add @ ExperimentalStdlibApi on Enum.entries for kotlin 1.9.x."

### DIFF
--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -961,15 +961,12 @@ public open class <lexer.name>(input: CharStream) : <superClass; null="Lexer">(i
     override val serializedATN: String =
         SERIALIZED_ATN
 
-    @kotlin.ExperimentalStdlibApi
     override val ruleNames: Array\<String> =
         Rules.entries.map(Rules::name).toTypedArray()
 
-    @kotlin.ExperimentalStdlibApi
     override val channelNames: Array\<String> =
         Channels.entries.map(Channels::name).toTypedArray()
 
-    @kotlin.ExperimentalStdlibApi
     override val modeNames: Array\<String> =
         Modes.entries.map(Modes::name).toTypedArray()
 


### PR DESCRIPTION

This reverts commit a1c9bfbec1b39628c2e5c3fd522f07595860cc34.

context: https://github.com/Strumenta/antlr-kotlin/pull/137#issuecomment-1876796044