### PR TITLE
Implement a multiplatform CopyOnWriteArrayList

### DIFF
--- a/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
@@ -1,0 +1,6 @@
+package com.strumenta.antlrkotlin.runtime
+
+public expect class CopyOnWriteArrayList<E>() : MutableList<E> {
+  // Convenience constructor to avoid initializing with mutable state
+  public constructor(elements: Collection<E>)
+}

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/ParserRuleContext.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/ParserRuleContext.kt
@@ -18,7 +18,7 @@ import kotlin.reflect.KClass
  * A rule invocation record for parsing.
  *
  * Contains all the information about the current rule not stored in the
- * RuleContext. It handles parse tree children list, any ATN state
+ * RuleContext. It handles parse-tree children list, any ATN state
  * tracing, and the default values available for rule invocations:
  * start, stop, rule index, current alt number.
  *
@@ -201,9 +201,8 @@ public open class ParserRuleContext : RuleContext {
    * If we have `# label`, we will need to remove generic `ruleContext` object.
    */
   public fun removeLastChild() {
-    children?.also {
-      it.removeAt(it.size - 1)
-    }
+    val tempChildren = children
+    tempChildren?.removeAt(tempChildren.size - 1)
   }
 
   override fun getChild(i: Int): ParseTree? {

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Recognizer.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Recognizer.kt
@@ -6,6 +6,7 @@
 
 package org.antlr.v4.kotlinruntime
 
+import com.strumenta.antlrkotlin.runtime.CopyOnWriteArrayList
 import com.strumenta.antlrkotlin.runtime.WeakHashMap
 import com.strumenta.antlrkotlin.runtime.synchronized
 import org.antlr.v4.kotlinruntime.atn.ATN
@@ -23,8 +24,7 @@ public abstract class Recognizer<Symbol, ATNInterpreter : ATNSimulator> {
     private val ruleIndexMapCache = WeakHashMap<Array<String>, Map<String, Int>>()
   }
 
-  // TODO: should be thread safe but is not!
-  private val _listeners = mutableListOf<ANTLRErrorListener>(ConsoleErrorListener.INSTANCE)
+  private val _listeners = CopyOnWriteArrayList<ANTLRErrorListener>(listOf(ConsoleErrorListener.INSTANCE))
 
   /**
    * Indicate that the recognizer has changed internal state that is

--- a/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
+++ b/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
@@ -1,0 +1,4 @@
+package com.strumenta.antlrkotlin.runtime
+
+// Note(Edoardo): JS is single threaded, so a normal list is good enough
+public actual typealias CopyOnWriteArrayList<E> = ArrayList<E>

--- a/antlr-kotlin-runtime/src/jvmMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
+++ b/antlr-kotlin-runtime/src/jvmMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
@@ -1,0 +1,3 @@
+package com.strumenta.antlrkotlin.runtime
+
+public actual typealias CopyOnWriteArrayList<E> = java.util.concurrent.CopyOnWriteArrayList<E>

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
@@ -1,0 +1,4 @@
+package com.strumenta.antlrkotlin.runtime
+
+// TODO(Edoardo): make thread safe at some point
+public actual typealias CopyOnWriteArrayList<E> = ArrayList<E>

--- a/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
+++ b/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
@@ -1,0 +1,4 @@
+package com.strumenta.antlrkotlin.runtime
+
+// Note(Edoardo): WASI is single threaded at the moment, so a normal list is good enough
+public actual typealias CopyOnWriteArrayList<E> = ArrayList<E>


### PR DESCRIPTION
A real `CopyOnWriteArrayList` is used only on the JVM side (like the Java runtime), as JS and WASM are still single threaded, and as Native is declared non thread-safe.