### PR TITLE
Improve nullability support for generated parsers

### DIFF
--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/ParserRuleContext.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/ParserRuleContext.kt
@@ -252,7 +252,7 @@ public open class ParserRuleContext : RuleContext {
       if (o is TerminalNode) {
         val symbol = o.symbol
 
-        if (symbol!!.type == ttype) {
+        if (symbol.type == ttype) {
           j++
 
           if (j == i) {
@@ -273,7 +273,7 @@ public open class ParserRuleContext : RuleContext {
       if (o is TerminalNode) {
         val symbol = o.symbol
 
-        if (symbol!!.type == ttype) {
+        if (symbol.type == ttype) {
           tokens.add(o)
         }
       }

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/TerminalNode.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/TerminalNode.kt
@@ -9,5 +9,5 @@ package org.antlr.v4.kotlinruntime.tree
 import org.antlr.v4.kotlinruntime.Token
 
 public interface TerminalNode : ParseTree {
-  public val symbol: Token?
+  public val symbol: Token
 }

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/TerminalNodeImpl.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/TerminalNodeImpl.kt
@@ -11,21 +11,20 @@ import org.antlr.v4.kotlinruntime.RuleContext
 import org.antlr.v4.kotlinruntime.Token
 import org.antlr.v4.kotlinruntime.misc.Interval
 
-public open class TerminalNodeImpl(override var symbol: Token?) : TerminalNode {
+public open class TerminalNodeImpl(override var symbol: Token) : TerminalNode {
   private var parent: ParseTree? = null
 
   override val childCount: Int = 0
 
   override val text: String
-    get() = symbol!!.text!!
+    get() = symbol.text!!
 
-  override val payload: Token?
+  override val payload: Token
     get() = symbol
 
   override val sourceInterval: Interval
     get() {
-      val tempSymbol = symbol ?: return Interval.INVALID
-      val tokenIndex = tempSymbol.tokenIndex
+      val tokenIndex = symbol.tokenIndex
       return Interval(tokenIndex, tokenIndex)
     }
 
@@ -46,10 +45,10 @@ public open class TerminalNodeImpl(override var symbol: Token?) : TerminalNode {
     toString()
 
   override fun toString(): String =
-    if (symbol!!.type == Token.EOF) {
+    if (symbol.type == Token.EOF) {
       "<EOF>"
     } else {
-      symbol!!.text!!
+      symbol.text!!
     }
 
   override fun toStringTree(): String =

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/Trees.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/Trees.kt
@@ -90,10 +90,7 @@ public object Trees {
         return t.toString()
       } else if (t is TerminalNode) {
         val symbol = t.symbol
-
-        if (symbol != null) {
-          return symbol.text!!
-        }
+        return symbol.text!!
       }
     }
 
@@ -189,7 +186,7 @@ public object Trees {
   ) {
     // Check this node (the root) first
     if (findTokens && t is TerminalNode) {
-      if (t.symbol!!.type == index) {
+      if (t.symbol.type == index) {
         nodes.add(t)
       }
     } else if (!findTokens && t is ParserRuleContext) {

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/Trees.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/Trees.kt
@@ -87,8 +87,13 @@ public object Trees {
             ruleName
           }
         }
-        is ErrorNode -> return t.toString()
-        is TerminalNode -> return t.symbol.text!!
+        is ErrorNode -> {
+          return t.toString()
+        }
+        is TerminalNode -> {
+          val text = t.symbol.text
+          return text ?: throw IllegalStateException("Symbol text should not be null")
+        }
       }
     }
 

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/Trees.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/Trees.kt
@@ -76,21 +76,19 @@ public object Trees {
 
   public fun getNodeText(t: Tree, ruleNames: List<String>?): String {
     if (ruleNames != null) {
-      if (t is RuleContext) {
-        val ruleIndex = t.ruleContext.ruleIndex
-        val ruleName = ruleNames[ruleIndex]
-        val altNumber = t.altNumber
-
-        return if (altNumber != ATN.INVALID_ALT_NUMBER) {
-          "$ruleName:$altNumber"
-        } else {
-          ruleName
+      when (t) {
+        is RuleContext -> {
+          val ruleIndex = t.ruleContext.ruleIndex
+          val ruleName = ruleNames[ruleIndex]
+          val altNumber = t.altNumber
+          return if (altNumber != ATN.INVALID_ALT_NUMBER) {
+            "$ruleName:$altNumber"
+          } else {
+            ruleName
+          }
         }
-      } else if (t is ErrorNode) {
-        return t.toString()
-      } else if (t is TerminalNode) {
-        val symbol = t.symbol
-        return symbol.text!!
+        is ErrorNode -> return t.toString()
+        is TerminalNode -> return t.symbol.text!!
       }
     }
 

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/pattern/ParseTreePatternMatcher.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/pattern/ParseTreePatternMatcher.kt
@@ -209,7 +209,7 @@ public open class ParseTreePatternMatcher(public val lexer: Lexer, public val pa
       var mismatchedNode: ParseTree? = null
 
       // Both are tokens and they have same type
-      if (tree.symbol?.type == patternTree.symbol?.type) {
+      if (tree.symbol.type == patternTree.symbol.type) {
         if (patternTree.symbol is TokenTagToken) { // x and <ID>
           val tokenTagToken = patternTree.symbol as TokenTagToken
 

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/xpath/XPathTokenElement.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/xpath/XPathTokenElement.kt
@@ -18,7 +18,7 @@ public open class XPathTokenElement(tokenName: String, protected var tokenType: 
 
     for (c in Trees.getChildren(t)) {
       if (c is TerminalNode) {
-        if (c.symbol!!.type == tokenType && !invert || c.symbol!!.type != tokenType && invert) {
+        if (c.symbol.type == tokenType && !invert || c.symbol.type != tokenType && invert) {
           nodes.add(c)
         }
       }

--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -741,7 +741,7 @@ TokenTypeDecl(t) ::= "var <t.name>: Int"
 TokenListDecl(t) ::= "<t.name>: MutableList\<Token> = ArrayList\<Token>()"
 RuleContextDecl(r) ::= "<r.name>: <r.ctxName>? = null"
 RuleContextListDecl(rdecl) ::= "<rdecl.name>: MutableList\<<rdecl.ctxName>> = ArrayList\<<rdecl.ctxName>>()"
-ContextTokenGetterDecl(t) ::= "public fun <t.name>(): TerminalNode? = getToken(Tokens.<t.name>.id, 0)"
+ContextTokenGetterDecl(t) ::= "public fun <t.name>(): TerminalNode<if(t.optional)>?<endif> = getToken(Tokens.<t.name>.id, 0)<if(!t.optional)>!!<endif>"
 ContextTokenListGetterDecl(t) ::= "public fun <t.name>(): List\<TerminalNode> = getTokens(Tokens.<t.name>.id)"
 
 ContextTokenListIndexedGetterDecl(t) ::= <<
@@ -749,15 +749,15 @@ public fun <t.name>(i: Int): TerminalNode = getToken(Tokens.<t.name>.id, i)!!
 >>
 
 ContextRuleGetterDecl(r) ::= <<
-public fun find<r.escapedName; format="cap">(): <r.ctxName>? = getRuleContext(<r.ctxName>::class, 0)
+public fun get<r.escapedName; format="cap">(): <r.ctxName><if(r.optional)>?<endif> = getRuleContext(<r.ctxName>::class, 0)<if(!r.optional)>!!<endif>
 >>
 
 ContextRuleListGetterDecl(r) ::= <<
-public fun find<r.escapedName; format="cap">(): List\<<r.ctxName>\> = getRuleContexts(<r.ctxName>::class)
+public fun get<r.escapedName; format="cap">(): List\<<r.ctxName>\> = getRuleContexts(<r.ctxName>::class)
 >>
 
 ContextRuleListIndexedGetterDecl(r) ::= <<
-public fun find<r.escapedName; format="cap">(i: Int): <r.ctxName>? = getRuleContext(<r.ctxName>::class, i)
+public fun get<r.escapedName; format="cap">(i: Int): <r.ctxName>? = getRuleContext(<r.ctxName>::class, i)
 >>
 
 LexerRuleContext() ::= "RuleContext"

--- a/antlr-kotlin-tests/src/commonTest/kotlin/com/strumenta/antlrkotlin/test/minicalc/MiniCalcParserTest.kt
+++ b/antlr-kotlin-tests/src/commonTest/kotlin/com/strumenta/antlrkotlin/test/minicalc/MiniCalcParserTest.kt
@@ -64,21 +64,21 @@ class MiniCalcParserTest {
     val lexer = MiniCalcLexer(input)
     val parser = MiniCalcParser(CommonTokenStream(lexer))
     val root = parser.miniCalcFile()
-    val line = root.findLine(0)!!
-    val statement = line.findStatement()!!
+    val line = root.getLine(0)!!
+    val statement = line.getStatement()
 
     @Suppress("UNUSED_VARIABLE")
     val inputDeclStmt = statement as MiniCalcParser.InputDeclarationStatementContext
-    val inputDecl = statement.findInputDeclaration()!!
+    val inputDecl = statement.getInputDeclaration()
 
     val inputKw = inputDecl.INPUT()
-    assertEquals("input", inputKw!!.text)
+    assertEquals("input", inputKw.text)
 
-    val type = inputDecl.findType()!!
+    val type = inputDecl.getType()
     val intKw = (type as MiniCalcParser.IntegerContext).INT()
-    assertEquals("Int", intKw!!.text)
+    assertEquals("Int", intKw.text)
 
-    val id = inputDecl.ID()!!
+    val id = inputDecl.ID()
     assertEquals("width", id.text)
 
     val newline = line.NEWLINE()!!


### PR DESCRIPTION
Improves type nullability support in generated parsers, and solves a part of #84.

In this case we are checking for the `optional` property - injected by the ANTLR code generator - on the `ContextTokenGetterDecl` and `ContextRuleGetterDecl` template parts.  
Note that the generated methods now start with `get*` instead of `find*`.

The missing part is for `TokenDecl`. We would have to use the `lateinit` modifier, but I'm still unsure if it's appropriate.