### PR TITLE
Enable the linuxArm32Hfp Native target

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,12 @@ The supported Native platforms are:
 | iosX64            | watchosX64            | androidNativeX64   |
 |                   | watchosArm32          | watchosDeviceArm64 |
 |                   | watchosArm64          | mingwX64           |
-|                   | tvosSimulatorArm64    |                    |
+|                   | tvosSimulatorArm64    | linuxArm32Hfp      |
 |                   | tvosX64               |                    |
 |                   | tvosArm64             |                    |
 |                   | iosArm64              |                    |
+
+> :warning: The `linuxArm32Hfp` platform is deprecated
 
 ## Gradle Setup
 

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/RuleContext.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/RuleContext.kt
@@ -137,8 +137,9 @@ public open class RuleContext : RuleNode {
    */
   public open var altNumber: Int
     get() = ATN.INVALID_ALT_NUMBER
-    // TODO(Edoardo): can we transform this to a 'val' and remove the setter?
-    set(@Suppress("UNUSED_PARAMETER") altNumber) {}
+    // Default implementation does nothing to avoid backing field
+    // overhead for trees that don't need it
+    set(@Suppress("UNUSED_PARAMETER") value) {}
 
   override val childCount: Int = 0
 

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/FlexibleHashMap.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/FlexibleHashMap.kt
@@ -36,14 +36,17 @@ public open class FlexibleHashMap<K, V>(
       "${key}:${value}"
   }
 
-  // TODO: are bucket entries actually nullable?
   protected var buckets: Array<MutableList<Entry<K, V>?>?>
 
   /**
    * How many elements in set.
    */
   protected var n: Int = 0
-  protected var currentPrime: Int = 1 // jump by 4 primes each expand or whatever
+
+  /**
+   * Jump by 4 primes each expand or whatever.
+   */
+  protected var currentPrime: Int = 1
 
   /**
    * When to expand.

--- a/buildSrc/src/main/kotlin/com/strumenta/antlrkotlin/gradle/plugins/StrumentaMultiplatformModuleExtension.kt
+++ b/buildSrc/src/main/kotlin/com/strumenta/antlrkotlin/gradle/plugins/StrumentaMultiplatformModuleExtension.kt
@@ -229,6 +229,11 @@ abstract class StrumentaMultiplatformModuleExtension(private val project: Projec
 
         // macOS host only
         kmpExtension.watchosDeviceArm64()
+
+        // Deprecated.
+        // Should follow the same route as official Kotlin libraries
+        @Suppress("DEPRECATION")
+        kmpExtension.linuxArm32Hfp()
       }
     }
   }

--- a/buildSrc/src/main/kotlin/com/strumenta/antlrkotlin/gradle/plugins/StrumentaMultiplatformModuleExtension.kt
+++ b/buildSrc/src/main/kotlin/com/strumenta/antlrkotlin/gradle/plugins/StrumentaMultiplatformModuleExtension.kt
@@ -194,46 +194,46 @@ abstract class StrumentaMultiplatformModuleExtension(private val project: Projec
     // Development should enable all targets.
     // Publishing should occur only from a macOS host
     if (isDevelopment || hostOs.isMacOsX) {
-      val kmpExtension = project.kmpExtension
       val disableUntestable = nativeConfig.disableUntestable.getOrElse(false)
+      with(project.kmpExtension) {
+        // Tier 1
+        // macOS host only
+        macosX64()
+        macosArm64()
+        iosSimulatorArm64()
+        iosX64()
 
-      // Tier 1
-      // macOS host only
-      kmpExtension.macosX64()
-      kmpExtension.macosArm64()
-      kmpExtension.iosSimulatorArm64()
-      kmpExtension.iosX64()
-
-      // Tier 2
-      kmpExtension.linuxX64()
-      kmpExtension.linuxArm64()
-
-      // macOS host only
-      kmpExtension.watchosSimulatorArm64()
-      kmpExtension.watchosX64()
-      kmpExtension.watchosArm32()
-      kmpExtension.watchosArm64()
-      kmpExtension.tvosSimulatorArm64()
-      kmpExtension.tvosX64()
-      kmpExtension.tvosArm64()
-      kmpExtension.iosArm64()
-
-      // Tier 3
-      kmpExtension.mingwX64()
-
-      if (!disableUntestable) {
-        kmpExtension.androidNativeArm32()
-        kmpExtension.androidNativeArm64()
-        kmpExtension.androidNativeX86()
-        kmpExtension.androidNativeX64()
+        // Tier 2
+        linuxX64()
+        linuxArm64()
 
         // macOS host only
-        kmpExtension.watchosDeviceArm64()
+        watchosSimulatorArm64()
+        watchosX64()
+        watchosArm32()
+        watchosArm64()
+        tvosSimulatorArm64()
+        tvosX64()
+        tvosArm64()
+        iosArm64()
 
-        // Deprecated.
-        // Should follow the same route as official Kotlin libraries
-        @Suppress("DEPRECATION")
-        kmpExtension.linuxArm32Hfp()
+        // Tier 3
+        mingwX64()
+
+        if (!disableUntestable) {
+          androidNativeArm32()
+          androidNativeArm64()
+          androidNativeX86()
+          androidNativeX64()
+
+          // macOS host only
+          watchosDeviceArm64()
+
+          // Deprecated.
+          // Should follow the same route as official Kotlin libraries
+          @Suppress("DEPRECATION")
+          linuxArm32Hfp()
+        }
       }
     }
   }


### PR DESCRIPTION
Other Kotlin libraries, like `kotlinx-serialization`, had to enable back the `linuxArm32Hfp` target.  
That target is still present, so we should also build for it.

See https://github.com/Kotlin/kotlinx.serialization/pull/2505