### PR TITLE
Properly assign values to multiple labels

### DIFF
--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -215,7 +215,7 @@ public open class <file.grammarName>BaseVisitor\<T> : AbstractParseTreeVisitor\<
      * The default implementation returns the result of calling [visitChildren] on [ctx].
      */
     override fun visit<lname; format="cap">(ctx: <file.parserName>.<lname; format="cap">Context): T {
-        return this.visitChildren(ctx)!!
+        return visitChildren(ctx)!!
     \}}; separator="\n">
 }
 
@@ -469,7 +469,7 @@ CodeBlockForAlt(currentAltCodeBlock, locals, preamble, ops) ::= <<
 >>
 
 LL1AltBlock(choice, preamble, alts, error) ::= <<
-this.state = <choice.stateNumber>
+state = <choice.stateNumber>
 errorHandler.sync(this)
 <if(choice.label)><labelref(choice.label)> = _input.LT(1)<endif>
 <preamble; separator="\n">
@@ -484,7 +484,7 @@ when (_input.LA(1)) {
 >>
 
 LL1OptionalBlock(choice, alts, error) ::= <<
-this.state = <choice.stateNumber>
+state = <choice.stateNumber>
 errorHandler.sync(this)
 
 when (_input.LA(1)) {
@@ -497,7 +497,7 @@ when (_input.LA(1)) {
 >>
 
 LL1OptionalBlockSingleAlt(choice, expr, alts, preamble, error, followExpr) ::= <<
-this.state = <choice.stateNumber>
+state = <choice.stateNumber>
 errorHandler.sync(this)
 <preamble; separator="\n">
 
@@ -507,26 +507,26 @@ if (<expr>) {
 >>
 
 LL1StarBlockSingleAlt(choice, loopExpr, alts, preamble, iteration) ::= <<
-this.state = <choice.stateNumber>
+state = <choice.stateNumber>
 errorHandler.sync(this)
 <preamble; separator="\n">
 
 while (<loopExpr>) {
     <alts; separator="\n">
-    this.state = <choice.loopBackStateNumber>
+    state = <choice.loopBackStateNumber>
     errorHandler.sync(this)
     <iteration>
 }
 >>
 
 LL1PlusBlockSingleAlt(choice, loopExpr, alts, preamble, iteration) ::= <<
-this.state = <choice.blockStartStateNumber> <! alt block decision !>
+state = <choice.blockStartStateNumber> <! alt block decision !>
 errorHandler.sync(this)
 <preamble; separator="\n">
 
 do {
     <alts; separator="\n">
-    this.state = <choice.stateNumber> <! loopback/exit decision !>
+    state = <choice.stateNumber> <! loopback/exit decision !>
     errorHandler.sync(this)
     <iteration>
 } while (<loopExpr>)
@@ -535,7 +535,7 @@ do {
 // LL(*) stuff
 
 AltBlock(choice, preamble, alts, error) ::= <<
-this.state = <choice.stateNumber>
+state = <choice.stateNumber>
 errorHandler.sync(this)
 <if(choice.label)><labelref(choice.label)> = _input.LT(1)<endif>
 <preamble; separator="\n">
@@ -549,7 +549,7 @@ when (interpreter.adaptivePredict(_input, <choice.decision>, context)) {
 >>
 
 OptionalBlock(choice, alts, error) ::= <<
-this.state = <choice.stateNumber>
+state = <choice.stateNumber>
 errorHandler.sync(this)
 
 when (interpreter.adaptivePredict(_input, <choice.decision>, context)) {
@@ -561,7 +561,7 @@ when (interpreter.adaptivePredict(_input, <choice.decision>, context)) {
 >>
 
 StarBlock(choice, alts, sync, iteration) ::= <<
-this.state = <choice.stateNumber>
+state = <choice.stateNumber>
 errorHandler.sync(this)
 _alt = interpreter.adaptivePredict(_input, <choice.decision>, context)
 
@@ -571,14 +571,14 @@ while (_alt != <choice.exitAlt> && _alt != INVALID_ALT_NUMBER) {
         <alts> <! should only be one !>
     }
 
-    this.state = <choice.loopBackStateNumber>
+    state = <choice.loopBackStateNumber>
     errorHandler.sync(this)
     _alt = interpreter.adaptivePredict(_input, <choice.decision>, context)
 }
 >>
 
 PlusBlock(choice, alts, error) ::= <<
-this.state = <choice.blockStartStateNumber> <! alt block decision !>
+state = <choice.blockStartStateNumber> <! alt block decision !>
 errorHandler.sync(this)
 _alt = 1<if(!choice.ast.greedy)> + 1<endif>
 
@@ -591,7 +591,7 @@ do {
         else -> <error>
     }
 
-    this.state = <choice.loopBackStateNumber> <! loopback/exit decision !>
+    state = <choice.loopBackStateNumber> <! loopback/exit decision !>
     errorHandler.sync(this)
     _alt = interpreter.adaptivePredict(_input, <choice.decision>, context)
 } while (_alt != <choice.exitAlt> && _alt != INVALID_ALT_NUMBER)
@@ -633,7 +633,7 @@ cases(tokens) ::= <<
 <tokens:{t | <t.name>}; separator=", "> -> >>
 
 InvokeRule(r, argExprsChunks) ::= <<
-this.state = <r.stateNumber>
+state = <r.stateNumber>
 <if(r.labels)>
 
 if (true) {
@@ -646,7 +646,7 @@ if (true) {
 >>
 
 MatchToken(m) ::= <<
-this.state = <m.stateNumber>
+state = <m.stateNumber>
 <if(m.labels)>
 
 if (true) {
@@ -663,7 +663,7 @@ MatchSet(m, expr, capture) ::= "<CommonSetStuff(m, expr, capture, false)>"
 MatchNotSet(m, expr, capture) ::= "<CommonSetStuff(m, expr, capture, true)>"
 
 CommonSetStuff(m, expr, capture, invert) ::= <<
-this.state = <m.stateNumber>
+state = <m.stateNumber>
 <if(m.labels)>
 
 if (true) {
@@ -692,7 +692,7 @@ else {
 >>
 
 Wildcard(w) ::= <<
-this.state = <w.stateNumber>
+state = <w.stateNumber>
 <if(w.labels)>
 
 val _mwc = matchWildcard()
@@ -709,7 +709,7 @@ Action(a, foo, chunks) ::= "<chunks>"
 ArgAction(a, chunks) ::= "<chunks>"
 
 SemPred(p, chunks, failChunks) ::= <<
-this.state = <p.stateNumber>
+state = <p.stateNumber>
 
 if (!(<chunks>)) {
     throw FailedPredicateException(this, <p.predicate><if(failChunks)>, <failChunks><elseif(p.msg)>, <p.msg><endif>)

--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -215,7 +215,7 @@ public open class <file.grammarName>BaseVisitor\<T> : AbstractParseTreeVisitor\<
      * The default implementation returns the result of calling [visitChildren] on [ctx].
      */
     override fun visit<lname; format="cap">(ctx: <file.parserName>.<lname; format="cap">Context): T {
-        return visitChildren(ctx)!!
+        return this.visitChildren(ctx)!!
     \}}; separator="\n">
 }
 
@@ -469,7 +469,7 @@ CodeBlockForAlt(currentAltCodeBlock, locals, preamble, ops) ::= <<
 >>
 
 LL1AltBlock(choice, preamble, alts, error) ::= <<
-state = <choice.stateNumber>
+this.state = <choice.stateNumber>
 errorHandler.sync(this)
 <if(choice.label)><labelref(choice.label)> = _input.LT(1)<endif>
 <preamble; separator="\n">
@@ -484,7 +484,7 @@ when (_input.LA(1)) {
 >>
 
 LL1OptionalBlock(choice, alts, error) ::= <<
-state = <choice.stateNumber>
+this.state = <choice.stateNumber>
 errorHandler.sync(this)
 
 when (_input.LA(1)) {
@@ -497,7 +497,7 @@ when (_input.LA(1)) {
 >>
 
 LL1OptionalBlockSingleAlt(choice, expr, alts, preamble, error, followExpr) ::= <<
-state = <choice.stateNumber>
+this.state = <choice.stateNumber>
 errorHandler.sync(this)
 <preamble; separator="\n">
 
@@ -507,26 +507,26 @@ if (<expr>) {
 >>
 
 LL1StarBlockSingleAlt(choice, loopExpr, alts, preamble, iteration) ::= <<
-state = <choice.stateNumber>
+this.state = <choice.stateNumber>
 errorHandler.sync(this)
 <preamble; separator="\n">
 
 while (<loopExpr>) {
     <alts; separator="\n">
-    state = <choice.loopBackStateNumber>
+    this.state = <choice.loopBackStateNumber>
     errorHandler.sync(this)
     <iteration>
 }
 >>
 
 LL1PlusBlockSingleAlt(choice, loopExpr, alts, preamble, iteration) ::= <<
-state = <choice.blockStartStateNumber> <! alt block decision !>
+this.state = <choice.blockStartStateNumber> <! alt block decision !>
 errorHandler.sync(this)
 <preamble; separator="\n">
 
 do {
     <alts; separator="\n">
-    state = <choice.stateNumber> <! loopback/exit decision !>
+    this.state = <choice.stateNumber> <! loopback/exit decision !>
     errorHandler.sync(this)
     <iteration>
 } while (<loopExpr>)
@@ -535,7 +535,7 @@ do {
 // LL(*) stuff
 
 AltBlock(choice, preamble, alts, error) ::= <<
-state = <choice.stateNumber>
+this.state = <choice.stateNumber>
 errorHandler.sync(this)
 <if(choice.label)><labelref(choice.label)> = _input.LT(1)<endif>
 <preamble; separator="\n">
@@ -549,7 +549,7 @@ when (interpreter.adaptivePredict(_input, <choice.decision>, context)) {
 >>
 
 OptionalBlock(choice, alts, error) ::= <<
-state = <choice.stateNumber>
+this.state = <choice.stateNumber>
 errorHandler.sync(this)
 
 when (interpreter.adaptivePredict(_input, <choice.decision>, context)) {
@@ -561,7 +561,7 @@ when (interpreter.adaptivePredict(_input, <choice.decision>, context)) {
 >>
 
 StarBlock(choice, alts, sync, iteration) ::= <<
-state = <choice.stateNumber>
+this.state = <choice.stateNumber>
 errorHandler.sync(this)
 _alt = interpreter.adaptivePredict(_input, <choice.decision>, context)
 
@@ -571,14 +571,14 @@ while (_alt != <choice.exitAlt> && _alt != INVALID_ALT_NUMBER) {
         <alts> <! should only be one !>
     }
 
-    state = <choice.loopBackStateNumber>
+    this.state = <choice.loopBackStateNumber>
     errorHandler.sync(this)
     _alt = interpreter.adaptivePredict(_input, <choice.decision>, context)
 }
 >>
 
 PlusBlock(choice, alts, error) ::= <<
-state = <choice.blockStartStateNumber> <! alt block decision !>
+this.state = <choice.blockStartStateNumber> <! alt block decision !>
 errorHandler.sync(this)
 _alt = 1<if(!choice.ast.greedy)> + 1<endif>
 
@@ -591,7 +591,7 @@ do {
         else -> <error>
     }
 
-    state = <choice.loopBackStateNumber> <! loopback/exit decision !>
+    this.state = <choice.loopBackStateNumber> <! loopback/exit decision !>
     errorHandler.sync(this)
     _alt = interpreter.adaptivePredict(_input, <choice.decision>, context)
 } while (_alt != <choice.exitAlt> && _alt != INVALID_ALT_NUMBER)
@@ -633,7 +633,7 @@ cases(tokens) ::= <<
 <tokens:{t | <t.name>}; separator=", "> -> >>
 
 InvokeRule(r, argExprsChunks) ::= <<
-state = <r.stateNumber>
+this.state = <r.stateNumber>
 <if(r.labels)>
 
 if (true) {
@@ -646,7 +646,7 @@ if (true) {
 >>
 
 MatchToken(m) ::= <<
-state = <m.stateNumber>
+this.state = <m.stateNumber>
 <if(m.labels)>
 
 if (true) {
@@ -663,7 +663,7 @@ MatchSet(m, expr, capture) ::= "<CommonSetStuff(m, expr, capture, false)>"
 MatchNotSet(m, expr, capture) ::= "<CommonSetStuff(m, expr, capture, true)>"
 
 CommonSetStuff(m, expr, capture, invert) ::= <<
-state = <m.stateNumber>
+this.state = <m.stateNumber>
 <if(m.labels)>
 
 if (true) {
@@ -692,7 +692,7 @@ else {
 >>
 
 Wildcard(w) ::= <<
-state = <w.stateNumber>
+this.state = <w.stateNumber>
 <if(w.labels)>
 
 val _mwc = matchWildcard()
@@ -709,7 +709,7 @@ Action(a, foo, chunks) ::= "<chunks>"
 ArgAction(a, chunks) ::= "<chunks>"
 
 SemPred(p, chunks, failChunks) ::= <<
-state = <p.stateNumber>
+this.state = <p.stateNumber>
 
 if (!(<chunks>)) {
     throw FailedPredicateException(this, <p.predicate><if(failChunks)>, <failChunks><elseif(p.msg)>, <p.msg><endif>)

--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -634,12 +634,28 @@ cases(tokens) ::= <<
 
 InvokeRule(r, argExprsChunks) ::= <<
 this.state = <r.stateNumber>
-<if(r.labels)><r.labels:{l | <labelref(l)> = }><endif><r.escapedName>(<if(r.ast.options.p)><r.ast.options.p><if(argExprsChunks)>,<endif><endif><argExprsChunks>)
+<if(r.labels)>
+
+if (true) {
+    val _ctx = <r.escapedName>(<if(r.ast.options.p)><r.ast.options.p><if(argExprsChunks)>, <endif><endif><argExprsChunks>)
+    <r.labels:{l | <labelref(l)> = _ctx}; separator="\n">
+}
+<else>
+<r.escapedName>(<if(r.ast.options.p)><r.ast.options.p><if(argExprsChunks)>, <endif><endif><argExprsChunks>)
+<endif>
 >>
 
 MatchToken(m) ::= <<
 this.state = <m.stateNumber>
-<if(m.labels)><m.labels:{l | <labelref(l)> = }><endif>match(<m.name>)
+<if(m.labels)>
+
+if (true) {
+    val _token = match(<m.name>)
+    <m.labels:{l | <labelref(l)> = _token}; separator="\n">
+}
+<else>
+match(<m.name>)
+<endif>
 >>
 
 MatchSet(m, expr, capture) ::= "<CommonSetStuff(m, expr, capture, false)>"
@@ -648,11 +664,22 @@ MatchNotSet(m, expr, capture) ::= "<CommonSetStuff(m, expr, capture, true)>"
 
 CommonSetStuff(m, expr, capture, invert) ::= <<
 this.state = <m.stateNumber>
-<if(m.labels)><m.labels:{l | <labelref(l)> = }>_input.LT(1)<endif>
+<if(m.labels)>
+
+if (true) {
+    val _token = _input.LT(1)
+    <m.labels:{l | <labelref(l)> = _token}; separator="\n">
+}
+<endif>
 <capture>
 
 if (<if(invert)><m.varName> \<= 0 || <else>!<endif>(<expr>)) {
-    <if(m.labels)><m.labels:{l | <labelref(l)> = errorHandler.recoverInline(this)}><else>errorHandler.recoverInline(this)<endif>
+    <if(m.labels)>
+    val _token = errorHandler.recoverInline(this)
+    <m.labels:{l | <labelref(l)> = _token}; separator="\n">
+    <else>
+    errorHandler.recoverInline(this)
+    <endif>
 }
 else {
     if (_input.LA(1) == Tokens.EOF) {
@@ -666,7 +693,13 @@ else {
 
 Wildcard(w) ::= <<
 this.state = <w.stateNumber>
-<if(w.labels)><w.labels:{l | <labelref(l)> = }><endif>matchWildcard()
+<if(w.labels)>
+
+val _mwc = matchWildcard()
+<w.labels:{l | <labelref(l)> = _mwc}; separator="\n">
+<else>
+matchWildcard()
+<endif>
 >>
 
 // Action stuff

--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -378,12 +378,13 @@ private fun <r.name>_sempred(_localctx: <r.ctxType>?, predIndex: Int): Boolean {
 }
 >>
 
-RuleFunction(currentRule,args,code,locals,ruleCtx,altLabelCtxs,namedActions,finallyAction,postamble,exceptions) ::= <<
+RuleFunction(currentRule, args, code, locals, ruleCtx, altLabelCtxs, namedActions, finallyAction, postamble, exceptions) ::= <<
 <ruleCtx>
 <altLabelCtxs:{l | <altLabelCtxs.(l)>}; separator="\n">
 
 public fun <if(currentRule.modifiers)><currentRule.modifiers:{f | <f> }><else><endif><currentRule.escapedName>(<args; separator=", ">): <currentRule.ctxType> {
     var _localctx = <currentRule.ctxType>(context, state<currentRule.args:{a | , <a.escapedName>}>)
+
     enterRule(_localctx, <currentRule.startState>, Rules.<currentRule.name; format="cap">)
     <namedActions.init>
     <locals; separator="\n">
@@ -428,6 +429,7 @@ private fun <currentRule.name>(_p: Int<args:{a | , <a>}>): <currentRule.ctxType>
     var _localctx = <currentRule.ctxType>(context, _parentState<currentRule.args:{a | , <a.name>}>)
     var _prevctx = _localctx
     var _startState = <currentRule.startState>
+
     enterRecursionRule(_localctx, <currentRule.startState>, Rules.<currentRule.name; format="cap">, _p)
     <namedActions.init>
     <locals; separator="\n">
@@ -461,11 +463,9 @@ enterOuterAlt(_localctx, <currentOuterMostAltCodeBlock.alt.altNum>)
 >>
 
 CodeBlockForAlt(currentAltCodeBlock, locals, preamble, ops) ::= <<
-if (true) {
-    <locals; separator="\n">
-    <preamble; separator="\n">
-    <ops; separator="\n">
-}
+<locals; separator="\n">
+<preamble; separator="\n">
+<ops; separator="\n">
 >>
 
 LL1AltBlock(choice, preamble, alts, error) ::= <<
@@ -735,7 +735,7 @@ LexerPushModeCommand(arg, grammar) ::= "pushMode(<arg>)"
 
 ActionText(t) ::= "<t.text>"
 ActionTemplate(t) ::= "<t.st>"
-ArgRef(a) ::= "_localctx!!.<a.name>"
+ArgRef(a) ::= "_localctx.<a.name>"
 LocalRef(a) ::= "_localctx.<a.name>"
 RetValueRef(a) ::= "_localctx.<a.name>"
 QRetValueRef(a) ::= "<ctx(a)>.<a.dict>.<a.name>"
@@ -744,7 +744,7 @@ QRetValueRef(a) ::= "<ctx(a)>.<a.dict>.<a.name>"
 TokenRef(t) ::= "<ctx(t)>.<t.name>"
 LabelRef(t) ::= "<ctx(t)>.<t.name>"
 ListLabelRef(t) ::= "<ctx(t)>.<ListLabelName(t.name)>"
-SetAttr(s, rhsChunks) ::= "<ctx(s)>.<s.name> = <rhsChunks>;"
+SetAttr(s, rhsChunks) ::= "<ctx(s)>.<s.name> = <rhsChunks>"
 
 TokenLabelType() ::= "<file.TokenLabelType; null={Token}>"
 InputSymbolType() ::= "<file.InputSymbolType; null={Token}>"
@@ -830,7 +830,7 @@ public open class <struct.name> : <if(contextSuperClass)><contextSuperClass><els
 
     public fun copyFrom(ctx: <struct.name>) {
         super.copyFrom(ctx)
-        <struct.attrs:{a | this.<a.name> = ctx.<a.name>;}; separator="\n">
+        <struct.attrs:{a | this.<a.name> = ctx.<a.name>}; separator="\n">
     }
     <endif>
     <dispatchMethods; separator="\n\n">
@@ -883,13 +883,13 @@ ctx(actionChunk) ::= "_localctx"
 // used for left-recursive rules
 recRuleAltPredicate(ruleName, opPrec) ::= "precpred(context!!, <opPrec>)"
 recRuleSetReturnAction(src, name) ::= "$<name> = $<src>.<name>"
-recRuleSetStopToken() ::= "this.context!!.stop = _input.LT(-1)"
+recRuleSetStopToken() ::= "context!!.stop = _input.LT(-1)"
 
 recRuleAltStartAction(ruleName, ctxName, label, isListLabel) ::= <<
 _localctx = <ctxName>Context(_parentctx, _parentState)
 <if(label)>
 <if(isListLabel)>
-_localctx.<label>.add(_prevctx!!)
+_localctx.<label>.add(_prevctx)
 <else>
 _localctx.<label> = _prevctx
 <endif>
@@ -901,7 +901,7 @@ recRuleLabeledAltStartAction(ruleName, currentAltLabel, label, isListLabel) ::= 
 _localctx = <currentAltLabel; format="cap">Context(<ruleName; format="cap">Context(_parentctx, _parentState))
 <if(label)>
 <if(isListLabel)>
-_localctx.<label>.add(_prevctx!!)
+_localctx.<label>.add(_prevctx)
 <else>
 _localctx.<label> = _prevctx
 <endif>


### PR DESCRIPTION
Being the template had been copied over from the Java runtime, multiple labels were being assigned a value like:

```
x = y = z = match(Tokens.ID)
```

Chained assignments aren't supported in Kotlin, so the new version uses:

```
val _token = match(Tokens.ID)
x = _token
y = _token
z = _token
```