### PR TITLE
Allow benchmarks on Native

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The scenario has been adapted from [antlr4ng][2].
   ./gradlew :antlr-kotlin-benchmarks:jvmBenchmark
   ```
 
-- JS and WebAssembly benchmarks cannot use kotlinx-benchmark currently.  
+- JS, WebAssembly and Native benchmarks cannot use kotlinx-benchmark currently.  
   Instead, they use a test case which re-uses the benchmark code.
 
   To run benchmarks, remove the `@Ignore` annotation on `ManualMySQLBenchmarks`, and use:
@@ -171,6 +171,10 @@ The scenario has been adapted from [antlr4ng][2].
   or
   ```
   ./gradlew :antlr-kotlin-benchmarks:wasmJsTest
+  ```
+  or
+  ```
+  ./gradlew :antlr-kotlin-benchmarks:mingwX64Test
   ```
 
 ## Maven Central Publication

--- a/antlr-kotlin-benchmarks/build.gradle.kts
+++ b/antlr-kotlin-benchmarks/build.gradle.kts
@@ -1,5 +1,6 @@
 @file:Suppress("UnstableApiUsage")
 
+import com.strumenta.antlrkotlin.gradle.ext.targetsNative
 import kotlinx.benchmark.gradle.JvmBenchmarkTarget
 import org.gradle.jvm.tasks.Jar
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
@@ -18,7 +19,20 @@ strumentaMultiplatform {
     browser = false
 
     // Benchmarks need quite some time to complete
-    testTimeout = 360
+    testsTimeout = 360
+  }
+
+  // Opting-in for native targets should be explicit,
+  // as it makes the build and test process slower.
+  //
+  // Opt in by setting 'target.is.native = true' in gradle.properties
+  if (targetsNative()) {
+    applyNative {
+      disableUntestable = true
+
+      // We want to benchmark a release binary, not a debug one
+      enableOptimizationInTests = true
+    }
   }
 }
 
@@ -46,6 +60,12 @@ kotlin {
         implementation(project.dependencies.platform(libs.kotlin.wrappers.bom.get()))
         implementation(libs.kotlin.wrappers.kotlin.js)
         implementation(libs.kotlin.wrappers.kotlin.node)
+      }
+    }
+
+    nativeMain {
+      dependencies {
+        implementation(libs.kotlinx.io.core)
       }
     }
   }

--- a/antlr-kotlin-benchmarks/src/nativeMain/kotlin/org/antlr/v4/kotlinruntime/benchmarks/IO.kt
+++ b/antlr-kotlin-benchmarks/src/nativeMain/kotlin/org/antlr/v4/kotlinruntime/benchmarks/IO.kt
@@ -1,0 +1,39 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package org.antlr.v4.kotlinruntime.benchmarks
+
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readString
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.native.CpuArchitecture.ARM64
+import kotlin.native.CpuArchitecture.X64
+import kotlin.native.OsFamily.*
+
+@OptIn(ExperimentalNativeApi::class)
+private val arch: String =
+  when (Platform.cpuArchitecture) {
+    X64 -> "X64"
+    ARM64 -> "Arm64"
+    else -> throw IllegalStateException("Unsupported CPU architecture")
+  }
+
+@OptIn(ExperimentalNativeApi::class)
+private val dir: String =
+  when (Platform.osFamily) {
+    WINDOWS -> "mingw$arch"
+    LINUX -> "linux$arch"
+    MACOSX -> "macos$arch"
+    else -> throw IllegalStateException("Unsupported OS family")
+  }
+
+// TODO(Edoardo): this should probably be replaced by a Gradle task,
+//  but in the meantime it should work consistently
+private val basePath = "build/processedResources/$dir/main"
+
+public actual fun readBenchmarkFile(name: String): String {
+  val path = Path("$basePath$name")
+  val source = SystemFileSystem.source(path).buffered()
+  return source.readString()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "1.9.22"
 kotlin-wrappers = "1.0.0-pre.683"
+kotlinx-io = "0.3.1"
 kotlinx-benchmark = "0.4.10"
 kotlinx-resources = "0.4.0"
 antlr4 = "4.13.1"
@@ -13,6 +14,7 @@ gradle-plugin-publish = "1.2.1"
 kotlin-wrappers-bom = { group = "org.jetbrains.kotlin-wrappers", name = "kotlin-wrappers-bom", version.ref = "kotlin-wrappers" }
 kotlin-wrappers-kotlin-js = { group = "org.jetbrains.kotlin-wrappers", name = "kotlin-js" }
 kotlin-wrappers-kotlin-node = { group = "org.jetbrains.kotlin-wrappers", name = "kotlin-node" }
+kotlinx-io-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-io-core", version.ref = "kotlinx-io" }
 kotlinx-benchmark = { group = "org.jetbrains.kotlinx", name = "kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark" }
 kotlinx-resources = { group = "com.goncalossilva", name = "resources", version.ref = "kotlinx-resources" }
 antlr4 = { group = "org.antlr", name = "antlr4", version.ref = "antlr4" }


### PR DESCRIPTION
Benchmarking Native is not really important for us, but we might use it to allow Kotlin/Native devs to improve the generated code performance.

To run the benchmark use:
```
./gradlew :antlr-kotlin-benchmarks:{platform}Test
```
For example:
```
./gradlew :antlr-kotlin-benchmarks:mingwX64Test
```