### PR TITLE
Solve name clashes on all platforms

### DIFF
--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -57,6 +57,7 @@ import org.antlr.v4.kotlinruntime.atn.ATN.Companion.INVALID_ALT_NUMBER
 import org.antlr.v4.kotlinruntime.dfa.*
 import org.antlr.v4.kotlinruntime.misc.*
 import org.antlr.v4.kotlinruntime.tree.*
+import kotlin.js.JsName
 import kotlin.jvm.JvmField
 
 <parser>
@@ -764,11 +765,11 @@ SetNonLocalAttr(s, rhsChunks) ::= "(getInvokingContext(<s.ruleIndex>) as <s.rule
 
 AddToLabelList(a) ::= "<ctx(a.label)>.<a.listName>.add(<labelref(a.label)>!!)"
 
-TokenDecl(t) ::= "<t.escapedName>: <TypeMap.(TokenLabelType())>? = null"
+TokenDecl(t) ::= "@JvmField @JsName(\"<t.escapedName>$\") public var <t.escapedName>: <TypeMap.(TokenLabelType())>? = null"
 TokenTypeDecl(t) ::= "var <t.escapedName>: Int"
-TokenListDecl(t) ::= "<t.escapedName>: MutableList\<Token> = ArrayList()"
-RuleContextDecl(r) ::= "<r.escapedName>: <r.ctxName>? = null"
-RuleContextListDecl(rdecl) ::= "<rdecl.escapedName>: MutableList\<<rdecl.ctxName>> = ArrayList()"
+TokenListDecl(t) ::= "@JvmField @JsName(\"<t.escapedName>$\") public var <t.escapedName>: MutableList\<Token> = ArrayList()"
+RuleContextDecl(r) ::= "@JvmField @JsName(\"<r.escapedName>$\") public var <r.escapedName>: <r.ctxName>? = null"
+RuleContextListDecl(rdecl) ::= "@JvmField @JsName(\"<rdecl.escapedName>$\") public var <rdecl.escapedName>: MutableList\<<rdecl.ctxName>> = ArrayList()"
 
 ContextTokenGetterDecl(t) ::= "public fun <t.escapedName>(): TerminalNode<if(t.optional)>?<endif> = getToken(Tokens.<t.escapedName>, 0)<if(!t.optional)>!!<endif>"
 ContextTokenListGetterDecl(t) ::= "public fun <t.escapedName>(): List\<TerminalNode> = getTokens(Tokens.<t.escapedName>)"
@@ -778,15 +779,15 @@ public fun <t.escapedName>(i: Int): TerminalNode? = getToken(Tokens.<t.escapedNa
 >>
 
 ContextRuleGetterDecl(r) ::= <<
-public fun get<r.escapedName; format="cap">(): <r.ctxName><if(r.optional)>?<endif> = getRuleContext(<r.ctxName>::class, 0)<if(!r.optional)>!!<endif>
+public fun <r.escapedName>(): <r.ctxName><if(r.optional)>?<endif> = getRuleContext(<r.ctxName>::class, 0)<if(!r.optional)>!!<endif>
 >>
 
 ContextRuleListGetterDecl(r) ::= <<
-public fun get<r.escapedName; format="cap">(): List\<<r.ctxName>\> = getRuleContexts(<r.ctxName>::class)
+public fun <r.escapedName>(): List\<<r.ctxName>\> = getRuleContexts(<r.ctxName>::class)
 >>
 
 ContextRuleListIndexedGetterDecl(r) ::= <<
-public fun get<r.escapedName; format="cap">(i: Int): <r.ctxName>? = getRuleContext(<r.ctxName>::class, i)
+public fun <r.escapedName>(i: Int): <r.ctxName>? = getRuleContext(<r.ctxName>::class, i)
 >>
 
 LexerRuleContext() ::= "RuleContext"
@@ -806,7 +807,7 @@ StructDecl(struct, ctorAttrs, attrs, getters, dispatchMethods, interfaces, exten
 public open class <struct.name> : <if(contextSuperClass)><contextSuperClass><else>ParserRuleContext<endif><if(interfaces)> : <interfaces; separator=", "><endif> {
     override val ruleIndex: Int = Rules.<struct.derivedFromName; format="cap">
 
-    <attrs:{a | @JvmField public var <a>}; separator="\n">
+    <attrs:{a | <a>}; separator="\n">
     <getters:{g | <g>}; separator="\n">
 
     public constructor(parent: ParserRuleContext?, invokingState: Int<ctorAttrs:{a | , <a>}>) : super(parent, invokingState) {
@@ -830,7 +831,7 @@ public open class <struct.name> : <if(contextSuperClass)><contextSuperClass><els
 
 AltLabelStructDecl(struct, attrs, getters, dispatchMethods) ::= <<
 public open class <struct.name> : <currentRule.name; format="cap">Context {
-    <attrs:{a | @JvmField public var <a>}; separator="\n">
+    <attrs:{a | <a>}; separator="\n">
     <getters:{g | <g>}; separator="\n">
 
     public constructor(ctx: <currentRule.name; format="cap">Context) {
@@ -860,7 +861,7 @@ override fun \<T> accept(visitor: ParseTreeVisitor\<out T>): T {
 }
 >>
 
-AttributeDecl(d) ::= "<d.escapedName>: <TypeMap.(d.type)><if(!IsPrimitiveTypeMap.(d.type))>?<endif> = <if(d.initValue)><d.initValue><else><TypeDefaultValueMap.(TypeMap.(d.type))><endif>"
+AttributeDecl(d) ::= "@JvmField @JsName(\"<d.escapedName>$\") public var <d.escapedName>: <TypeMap.(d.type)><if(!IsPrimitiveTypeMap.(d.type))>?<endif> = <if(d.initValue)><d.initValue><else><TypeDefaultValueMap.(TypeMap.(d.type))><endif>"
 
 // If we don't know location of label def x, use this template
 labelref(x) ::= "<if(!x.isLocal)>_localctx.<endif><x.escapedName>"

--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -97,7 +97,8 @@ public interface <file.grammarName>Listener : ParseTreeListener {
      *
      * @param ctx The parse tree
      */
-    public fun exit<lname; format="cap">(ctx: <file.parserName>.<lname; format="cap">Context)}; separator="\n">
+    public fun exit<lname; format="cap">(ctx: <file.parserName>.<lname; format="cap">Context)
+}; separator="\n">
 }
 
 >>
@@ -180,7 +181,8 @@ public interface <file.grammarName>Visitor\<T> : ParseTreeVisitor\<T> {
      * @param ctx The parse tree
      * @return The visitor result
      */
-    public fun visit<lname; format="cap">(ctx: <file.parserName>.<lname; format="cap">Context): T}; separator="\n">
+    public fun visit<lname; format="cap">(ctx: <file.parserName>.<lname; format="cap">Context): T
+}; separator="\n">
 }
 
 >>
@@ -223,7 +225,7 @@ Parser(parser, funcs, atn, sempredFuncs, superClass) ::= <<
 >>
 
 Parser_(parser, funcs, atn, sempredFuncs, superClass) ::= <<
-@Suppress("UNUSED_VARIABLE", "ClassName", "FunctionName", "LocalVariableName", "ConstPropertyName", "ConvertSecondaryConstructorToPrimary")
+@Suppress("UNUSED_VARIABLE", "ClassName", "FunctionName", "LocalVariableName", "ConstPropertyName", "ConvertSecondaryConstructorToPrimary", "CanBeVal")
 public open class <parser.name>(input: TokenStream) : <superClass; null="Parser">(input) {
     private companion object {
         init {

--- a/antlr-kotlin-tests/src/commonTest/kotlin/com/strumenta/antlrkotlin/test/minicalc/MiniCalcParserTest.kt
+++ b/antlr-kotlin-tests/src/commonTest/kotlin/com/strumenta/antlrkotlin/test/minicalc/MiniCalcParserTest.kt
@@ -64,17 +64,17 @@ class MiniCalcParserTest {
     val lexer = MiniCalcLexer(input)
     val parser = MiniCalcParser(CommonTokenStream(lexer))
     val root = parser.miniCalcFile()
-    val line = root.getLine(0)!!
-    val statement = line.getStatement()
+    val line = root.line(0)!!
+    val statement = line.statement()
 
     @Suppress("UNUSED_VARIABLE")
     val inputDeclStmt = statement as MiniCalcParser.InputDeclarationStatementContext
-    val inputDecl = statement.getInputDeclaration()
+    val inputDecl = statement.inputDeclaration()
 
     val inputKw = inputDecl.INPUT()
     assertEquals("input", inputKw.text)
 
-    val type = inputDecl.getType()
+    val type = inputDecl.type()
     val intKw = (type as MiniCalcParser.IntegerContext).INT()
     assertEquals("Int", intKw.text)
 


### PR DESCRIPTION
Alongside `@JvmField` we now also use `@JsName`, with a `$` as name's suffix.  
This closes the chapter of name clashes on all platforms.

Fixes: #172