### PR TITLE
Improve type nullability for IntervalSet

### DIFF
--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATNSerializer.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATNSerializer.kt
@@ -201,7 +201,7 @@ public open class ATNSerializer(public var atn: ATN) {
 
         val src = s.stateNumber
         var trg = t.target.stateNumber
-        val edgeType = Transition.serializationTypes[t::class]!!
+        val edgeType = t.serializationType
         var arg1 = 0
         var arg2 = 0
         var arg3 = 0
@@ -360,7 +360,7 @@ public open class ATNSerializer(public var atn: ATN) {
 
       for (i in 0..<s.numberOfTransitions) {
         val t = s.transition(i)
-        val edgeType = Transition.serializationTypes[t::class]!!
+        val edgeType = t.serializationType
 
         if (edgeType == Transition.SET || edgeType == Transition.NOT_SET) {
           val st = t as SetTransition

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATNSerializer.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATNSerializer.kt
@@ -24,7 +24,7 @@ public open class ATNSerializer(public var atn: ATN) {
 
       for (set in sets) {
         val containsEof = set.contains(Token.EOF)
-        val intervals = set.intervals!!
+        val intervals = set.intervals
 
         if (containsEof && intervals[0].b == Token.EOF) {
           data.add(intervals.size - 1)

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATNState.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATNState.kt
@@ -41,7 +41,7 @@ public abstract class ATNState {
     public const val PLUS_LOOP_BACK: Int = 11
     public const val LOOP_END: Int = 12
 
-    public val serializationNames: List<String> = listOf(
+    public val serializationNames: Array<String> = arrayOf(
       "INVALID",
       "BASIC",
       "RULE_START",
@@ -54,7 +54,7 @@ public abstract class ATNState {
       "STAR_LOOP_BACK",
       "STAR_LOOP_ENTRY",
       "PLUS_LOOP_BACK",
-      "LOOP_END"
+      "LOOP_END",
     )
 
     public const val INVALID_STATE_NUMBER: Int = -1

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/Transition.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/Transition.kt
@@ -5,7 +5,6 @@ package org.antlr.v4.kotlinruntime.atn
 
 import org.antlr.v4.kotlinruntime.misc.IntervalSet
 import kotlin.js.JsName
-import kotlin.reflect.KClass
 
 /**
  * An ATN transition between any two ATN states.
@@ -37,7 +36,7 @@ public abstract class Transition protected constructor(public var target: ATNSta
     public const val WILDCARD: Int = 9
     public const val PRECEDENCE: Int = 10
 
-    public val serializationNames: List<String> = listOf(
+    public val serializationNames: Array<String> = arrayOf(
       "INVALID",
       "EPSILON",
       "RANGE",
@@ -48,21 +47,8 @@ public abstract class Transition protected constructor(public var target: ATNSta
       "SET",
       "NOT_SET",
       "WILDCARD",
-      "PRECEDENCE"
+      "PRECEDENCE",
     )
-
-    public val serializationTypes: Map<KClass<out Transition>, Int> = buildMap {
-      put(EpsilonTransition::class, EPSILON)
-      put(RangeTransition::class, RANGE)
-      put(RuleTransition::class, RULE)
-      put(PredicateTransition::class, PREDICATE)
-      put(AtomTransition::class, ATOM)
-      put(ActionTransition::class, ACTION)
-      put(SetTransition::class, SET)
-      put(NotSetTransition::class, NOT_SET)
-      put(WildcardTransition::class, WILDCARD)
-      put(PrecedencePredicateTransition::class, PRECEDENCE)
-    }
   }
 
   public abstract val serializationType: Int

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/IntSet.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/IntSet.kt
@@ -33,7 +33,7 @@ public interface IntSet {
    *
    * @throws IllegalStateException If the current set is read-only
    */
-  public fun addAll(set: IntSet?): IntSet
+  public fun addAll(set: IntSet): IntSet
 
   /**
    * Return a new [IntSet] object containing all elements that are
@@ -45,7 +45,7 @@ public interface IntSet {
    *   current set and `a`. The value `null` may be returned in
    *   place of an empty result set
    */
-  public fun and(a: IntSet?): IntSet?
+  public fun and(a: IntSet): IntSet
 
   /**
    * Return a new [IntSet] object containing all elements that are
@@ -63,7 +63,7 @@ public interface IntSet {
    *   `elements` but not present in the current set. The value
    *   `null` may be returned in place of an empty result set
    */
-  public fun complement(elements: IntSet?): IntSet?
+  public fun complement(elements: IntSet): IntSet
 
   /**
    * Return a new [IntSet] object containing all elements that are
@@ -78,7 +78,7 @@ public interface IntSet {
    *   set and `a`. The value `null` may be returned in place of an
    *   empty result set
    */
-  public fun or(a: IntSet?): IntSet
+  public fun or(a: IntSet): IntSet
 
   /**
    * Return a new [IntSet] object containing all elements that are
@@ -96,7 +96,7 @@ public interface IntSet {
    *   `elements` but not present in the current set.
    *   The value `null` may be returned in place of an empty result set
    */
-  public fun subtract(a: IntSet?): IntSet
+  public fun subtract(a: IntSet): IntSet
 
   /**
    * Return the total number of elements represented by the current set.
@@ -112,7 +112,7 @@ public interface IntSet {
    * @param el The element to check for
    * @return `true` if the set contains `el`, otherwise `false`
    */
-  public operator fun contains(el: Int): Boolean
+  public fun contains(el: Int): Boolean
 
   /**
    * Removes the specified value from the current set.
@@ -133,6 +133,6 @@ public interface IntSet {
   public fun toList(): List<Int>
 
   override fun equals(other: Any?): Boolean
-
+  override fun hashCode(): Int
   override fun toString(): String
 }

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/IntervalSet.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/IntervalSet.kt
@@ -143,7 +143,7 @@ public class IntervalSet : IntSet {
     }
   }
 
-  private var _intervals: MutableList<Interval> = ArrayList(8)
+  private val _intervals: MutableList<Interval>
 
   /**
    * The list of sorted, disjoint intervals.
@@ -194,20 +194,21 @@ public class IntervalSet : IntSet {
       field = value
     }
 
+  // This is the most used constructor.
+  // Before, the vararg one was getting used, allocating an IntArray for no reason
+  public constructor() {
+    // The initial size of 16 is a best guess by evaluating
+    // the size when executed under multiple grammars
+    _intervals = ArrayList(16)
+  }
+
   public constructor(intervals: MutableList<Interval>) {
     _intervals = intervals
   }
 
-  public constructor(set: IntervalSet) : this() {
+  public constructor(set: IntervalSet) {
+    _intervals = ArrayList(set._intervals.size)
     addAll(set)
-  }
-
-  public constructor(vararg els: Int) {
-    _intervals = ArrayList(els.size)
-
-    for (e in els) {
-      add(e)
-    }
   }
 
   public fun clear() {

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/IntervalSet.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/IntervalSet.kt
@@ -485,10 +485,10 @@ public class IntervalSet : IntSet {
     }
 
     val n = _intervals.size
-    var i = 0
+    var index = 0
 
-    while (i < n) {
-      val I = _intervals[i++]
+    while (index < n) {
+      val I = _intervals[index++]
       val a = I.a
       val b = I.b
 
@@ -516,7 +516,7 @@ public class IntervalSet : IntSet {
         }
       }
 
-      if (i < n) {
+      if (index < n) {
         buf.append(", ")
       }
     }
@@ -540,10 +540,10 @@ public class IntervalSet : IntSet {
     }
 
     val n = _intervals.size
-    var i = 0
+    var index = 0
 
-    while (i < n) {
-      val I = _intervals[i++]
+    while (index < n) {
+      val I = _intervals[index++]
       val a = I.a
       val b = I.b
 
@@ -559,7 +559,7 @@ public class IntervalSet : IntSet {
         }
       }
 
-      if (i < n) {
+      if (index < n) {
         buf.append(", ")
       }
     }


### PR DESCRIPTION
`IntervalSet` seems to be a hot path, so the less nullability checks we have, and the less iterators we use, the better.

Also tested with the ANTLR 5 test suite.