### PR TITLE
Alias kotlin.js.JsName to allow JVM-only projects to compile

### DIFF
--- a/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
@@ -18,5 +18,4 @@ package com.strumenta.antlrkotlin.runtime
   AnnotationTarget.PROPERTY_GETTER,
   AnnotationTarget.PROPERTY_SETTER,
 )
-@Retention(AnnotationRetention.SOURCE)
 public expect annotation class JsName(val name: String)

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
@@ -1,0 +1,22 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package com.strumenta.antlrkotlin.runtime
+
+/**
+ * A typealias for Kotlin's `JsName` in the `js` and `wasmJs` targets,
+ * and a non-retained annotation for all the other targets.
+ *
+ * It should be used **only** in `Kotlin.stg`.
+ *
+ * See [issues/175](https://github.com/Strumenta/antlr-kotlin/issues/175) for more details.
+ */
+@Target(
+  AnnotationTarget.CLASS,
+  AnnotationTarget.FUNCTION,
+  AnnotationTarget.PROPERTY,
+  AnnotationTarget.CONSTRUCTOR,
+  AnnotationTarget.PROPERTY_GETTER,
+  AnnotationTarget.PROPERTY_SETTER,
+)
+@Retention(AnnotationRetention.SOURCE)
+public expect annotation class JsName(val name: String)

--- a/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
+++ b/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
@@ -2,5 +2,4 @@
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
 package com.strumenta.antlrkotlin.runtime
 
-@Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")
 public actual typealias JsName = kotlin.js.JsName

--- a/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
+++ b/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
@@ -1,0 +1,6 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package com.strumenta.antlrkotlin.runtime
+
+@Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")
+public actual typealias JsName = kotlin.js.JsName

--- a/antlr-kotlin-runtime/src/jvmMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
+++ b/antlr-kotlin-runtime/src/jvmMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
@@ -1,0 +1,14 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package com.strumenta.antlrkotlin.runtime
+
+@Target(
+  AnnotationTarget.CLASS,
+  AnnotationTarget.FUNCTION,
+  AnnotationTarget.PROPERTY,
+  AnnotationTarget.CONSTRUCTOR,
+  AnnotationTarget.PROPERTY_GETTER,
+  AnnotationTarget.PROPERTY_SETTER,
+)
+@Retention(AnnotationRetention.SOURCE)
+public actual annotation class JsName(actual val name: String)

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
@@ -1,0 +1,14 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package com.strumenta.antlrkotlin.runtime
+
+@Target(
+  AnnotationTarget.CLASS,
+  AnnotationTarget.FUNCTION,
+  AnnotationTarget.PROPERTY,
+  AnnotationTarget.CONSTRUCTOR,
+  AnnotationTarget.PROPERTY_GETTER,
+  AnnotationTarget.PROPERTY_SETTER,
+)
+@Retention(AnnotationRetention.SOURCE)
+public actual annotation class JsName(actual val name: String)

--- a/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
+++ b/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
@@ -2,5 +2,4 @@
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
 package com.strumenta.antlrkotlin.runtime
 
-@Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")
 public actual typealias JsName = kotlin.js.JsName

--- a/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
+++ b/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
@@ -1,0 +1,6 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package com.strumenta.antlrkotlin.runtime
+
+@Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")
+public actual typealias JsName = kotlin.js.JsName

--- a/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
+++ b/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/JsName.kt
@@ -1,0 +1,14 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package com.strumenta.antlrkotlin.runtime
+
+@Target(
+  AnnotationTarget.CLASS,
+  AnnotationTarget.FUNCTION,
+  AnnotationTarget.PROPERTY,
+  AnnotationTarget.CONSTRUCTOR,
+  AnnotationTarget.PROPERTY_GETTER,
+  AnnotationTarget.PROPERTY_SETTER,
+)
+@Retention(AnnotationRetention.SOURCE)
+public actual annotation class JsName(actual val name: String)

--- a/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
+++ b/antlr-kotlin-target/src/main/resources/org/antlr/v4/tool/templates/codegen/Kotlin/Kotlin.stg
@@ -51,13 +51,13 @@ package <file.genPackage>
 <endif>
 <namedActions.header>
 
+import com.strumenta.antlrkotlin.runtime.JsName
 import org.antlr.v4.kotlinruntime.*
 import org.antlr.v4.kotlinruntime.atn.*
 import org.antlr.v4.kotlinruntime.atn.ATN.Companion.INVALID_ALT_NUMBER
 import org.antlr.v4.kotlinruntime.dfa.*
 import org.antlr.v4.kotlinruntime.misc.*
 import org.antlr.v4.kotlinruntime.tree.*
-import kotlin.js.JsName
 import kotlin.jvm.JvmField
 
 <parser>
@@ -225,7 +225,18 @@ Parser(parser, funcs, atn, sempredFuncs, superClass) ::= <<
 >>
 
 Parser_(parser, funcs, atn, sempredFuncs, superClass) ::= <<
-@Suppress("UNUSED_VARIABLE", "ClassName", "FunctionName", "LocalVariableName", "ConstPropertyName", "ConvertSecondaryConstructorToPrimary", "CanBeVal")
+@Suppress(
+    // This is required as we are using a custom JsName alias that is not recognized by the IDE.
+    // No name clashes will happen tho.
+    "JS_NAME_CLASH",
+    "UNUSED_VARIABLE",
+    "ClassName",
+    "FunctionName",
+    "LocalVariableName",
+    "ConstPropertyName",
+    "ConvertSecondaryConstructorToPrimary",
+    "CanBeVal",
+)
 public open class <parser.name>(input: TokenStream) : <superClass; null="Parser">(input) {
     private companion object {
         init {
@@ -932,7 +943,12 @@ import org.antlr.v4.kotlinruntime.misc.*
 >>
 
 Lexer(lexer, atn, actionFuncs, sempredFuncs, superClass) ::= <<
-@Suppress("ClassName", "FunctionName", "LocalVariableName", "ConstPropertyName")
+@Suppress(
+    "ClassName",
+    "FunctionName",
+    "LocalVariableName",
+    "ConstPropertyName",
+)
 public open class <lexer.name>(input: CharStream) : <superClass; null="Lexer">(input) {
     private companion object {
         init {


### PR DESCRIPTION
Fixes: #175