### PR TITLE
Remove the Canary version of Node.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,5 @@ Desktop.ini
 *~
 .directory
 .merge_file*
-.idea
+.idea/
+.kotlin/

--- a/buildSrc/src/main/kotlin/com/strumenta/antlrkotlin/gradle/plugins/StrumentaMultiplatformModulePlugin.kt
+++ b/buildSrc/src/main/kotlin/com/strumenta/antlrkotlin/gradle/plugins/StrumentaMultiplatformModulePlugin.kt
@@ -4,14 +4,10 @@ import com.strumenta.antlrkotlin.gradle.ext.kmpExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
-import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.create
-import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
-import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
 import org.jetbrains.kotlin.gradle.targets.js.yarn.yarn
 
 /**
@@ -44,23 +40,6 @@ class StrumentaMultiplatformModulePlugin : Plugin<Project> {
       apiVersion.set(KotlinVersion.KOTLIN_1_9)
       languageVersion.set(KotlinVersion.KOTLIN_1_9)
       freeCompilerArgs.add("-Xexpect-actual-classes")
-    }
-
-    // The following is required to support the wasmJs target.
-    //
-    // Node.js Canary is set to 21.0.0-v8-canary20231019bd785be450
-    // as that is the last version to ship Windows binaries too.
-    project.rootProject.extensions.configure<NodeJsRootExtension> {
-      nodeVersion = "21.0.0-v8-canary20231019bd785be450"
-      nodeDownloadBaseUrl = "https://nodejs.org/download/v8-canary"
-    }
-
-    project.rootProject.tasks.withType<KotlinNpmInstallTask>().configureEach {
-      val flag = "--ignore-engines"
-
-      if (!args.contains(flag)) {
-        args.add(flag)
-      }
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.9.23"
+kotlin = "1.9.24"
 kotlin-wrappers = "1.0.0-pre.729"
 kotlinx-io = "0.3.1"
 kotlinx-benchmark = "0.4.10"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "1.9.24"
 kotlin-wrappers = "1.0.0-pre.748"
-kotlinx-io = "0.3.1"
+kotlinx-io = "0.3.4"
 kotlinx-benchmark = "0.4.10"
 kotlinx-resources = "0.4.1"
 antlr4 = "4.13.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "1.9.24"
-kotlin-wrappers = "1.0.0-pre.729"
+kotlin-wrappers = "1.0.0-pre.748"
 kotlinx-io = "0.3.1"
 kotlinx-benchmark = "0.4.10"
 kotlinx-resources = "0.4.1"


### PR DESCRIPTION
Updating to Kotlin 1.9.24 ensures we are using Node.js 22, which supports WASM GC without flags.