### PR TITLE
Rework native logging to remove suppressions

### DIFF
--- a/antlr-kotlin-runtime/src/androidNativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
+++ b/antlr-kotlin-runtime/src/androidNativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
@@ -1,0 +1,10 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package com.strumenta.antlrkotlin.runtime
+
+import platform.android.ANDROID_LOG_ERROR
+import platform.android.__android_log_print
+
+internal actual fun androidPrintErr(message: String) {
+  __android_log_print(ANDROID_LOG_ERROR.toInt(), "antlr-kotlin", message)
+}

--- a/antlr-kotlin-runtime/src/appleMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
+++ b/antlr-kotlin-runtime/src/appleMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
@@ -1,0 +1,5 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package com.strumenta.antlrkotlin.runtime
+
+internal actual fun androidPrintErr(message: String): Unit = error("Should not be called")

--- a/antlr-kotlin-runtime/src/linuxMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
+++ b/antlr-kotlin-runtime/src/linuxMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
@@ -1,0 +1,5 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package com.strumenta.antlrkotlin.runtime
+
+internal actual fun androidPrintErr(message: String): Unit = error("Should not be called")

--- a/antlr-kotlin-runtime/src/mingwMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
+++ b/antlr-kotlin-runtime/src/mingwMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
@@ -1,0 +1,5 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package com.strumenta.antlrkotlin.runtime
+
+internal actual fun androidPrintErr(message: String): Unit = error("Should not be called")

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Console.kt
@@ -1,25 +1,43 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-@file:Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
-
 package com.strumenta.antlrkotlin.runtime
 
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.fflush
+import platform.posix.fprintf
+import platform.posix.stderr
 import kotlin.experimental.ExperimentalNativeApi
-import kotlin.native.internal.GCUnsafeCall
-import kotlin.native.internal.InternalForKotlinNative
+
+// Must throw an exception in all platforms but Android
+internal expect fun androidPrintErr(message: String)
+
+internal actual fun platformPrintErrLn(): Unit =
+  printImpl(lineBreak)
+
+internal actual fun platformPrintErrLn(message: String): Unit =
+  printImpl("$message$lineBreak")
+
+internal actual fun platformPrintErr(message: String): Unit =
+  printImpl(message)
 
 @OptIn(ExperimentalNativeApi::class)
 private val lineBreak = if (Platform.osFamily == OsFamily.WINDOWS) "\r\n" else "\n"
 
-@OptIn(InternalForKotlinNative::class)
-@GCUnsafeCall("Kotlin_io_Console_printToStdErr")
-private external fun runtimePrintToStdErr(message: String)
+// Let me explain what is going on here, why we have a generic
+// function for all native targets and a specific one for Android.
+//
+// Why can't we simply declare nativePrintErr an expect function
+// and implement it in appleMain/linuxMain/mingwMain/androidNativeMain?
+//
+// The answer is fprintf and fflush are not available under appleMain
+// for some reason, even if they should be, and thus the compilation fails.
+// This strategy is a temporary workaround until the problem is fixed.
 
-internal actual inline fun platformPrintErrLn(): Unit =
-  runtimePrintToStdErr(lineBreak)
+@OptIn(ExperimentalNativeApi::class)
+private val printImpl = if (Platform.osFamily == OsFamily.ANDROID) ::androidPrintErr else ::nativePrintErr
 
-internal actual inline fun platformPrintErrLn(message: String): Unit =
-  runtimePrintToStdErr("$message$lineBreak")
-
-internal actual inline fun platformPrintErr(message: String): Unit =
-  runtimePrintToStdErr(message)
+@OptIn(ExperimentalForeignApi::class)
+private fun nativePrintErr(message: String) {
+  fprintf(stderr, message)
+  fflush(stderr)
+}


### PR DESCRIPTION
The `INVISIBLE_MEMBER` and `INVISIBLE_REFERENCE` suppressions are going away some time post 2.0.

In the scope of releasing 1.0.0.