### PR TITLE
Add the JvmField annotation where appropriate

### DIFF
--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/CommonToken.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/CommonToken.kt
@@ -3,6 +3,7 @@
 package org.antlr.v4.kotlinruntime
 
 import org.antlr.v4.kotlinruntime.misc.Interval
+import kotlin.jvm.JvmField
 
 public open class CommonToken : WritableToken {
   protected companion object {
@@ -10,6 +11,7 @@ public open class CommonToken : WritableToken {
      * An empty pair which is used as the default value of
      * [source] for tokens that do not have a source.
      */
+    @JvmField
     protected val EMPTY_SOURCE: Pair<TokenSource?, CharStream?> = Pair<TokenSource?, CharStream?>(null, null)
   }
 

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/CommonTokenFactory.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/CommonTokenFactory.kt
@@ -1,9 +1,9 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package org.antlr.v4.kotlinruntime
 
 import org.antlr.v4.kotlinruntime.misc.Interval
+import kotlin.jvm.JvmField
 
 /**
  * This default implementation of [TokenFactory] creates [CommonToken] objects.
@@ -33,6 +33,7 @@ public open class CommonTokenFactory(
      *
      * This token factory does not explicitly copy token text when constructing tokens.
      */
+    @JvmField
     public val DEFAULT: TokenFactory<CommonToken> = CommonTokenFactory()
   }
 

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/ConsoleErrorListener.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/ConsoleErrorListener.kt
@@ -3,6 +3,7 @@
 package org.antlr.v4.kotlinruntime
 
 import com.strumenta.antlrkotlin.runtime.System
+import kotlin.jvm.JvmField
 
 /**
  * @author Sam Harwell
@@ -12,6 +13,7 @@ public open class ConsoleErrorListener : BaseErrorListener() {
     /**
      * Provides a default instance of [ConsoleErrorListener].
      */
+    @JvmField
     public val INSTANCE: ConsoleErrorListener = ConsoleErrorListener()
   }
 

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/ParserRuleContext.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/ParserRuleContext.kt
@@ -8,7 +8,7 @@ import org.antlr.v4.kotlinruntime.tree.ErrorNode
 import org.antlr.v4.kotlinruntime.tree.ParseTree
 import org.antlr.v4.kotlinruntime.tree.ParseTreeListener
 import org.antlr.v4.kotlinruntime.tree.TerminalNode
-import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmField
 import kotlin.reflect.KClass
 
 /**
@@ -37,7 +37,7 @@ import kotlin.reflect.KClass
 @Suppress("MemberVisibilityCanBePrivate")
 public open class ParserRuleContext : RuleContext {
   public companion object {
-    @JvmStatic
+    @JvmField
     public val EMPTY: ParserRuleContext = ParserRuleContext()
   }
 

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/VocabularyImpl.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/VocabularyImpl.kt
@@ -2,6 +2,7 @@
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
 package org.antlr.v4.kotlinruntime
 
+import kotlin.jvm.JvmField
 import kotlin.math.max
 
 /**
@@ -34,6 +35,7 @@ public class VocabularyImpl(
      * [getDisplayName] returns the numeric value for all tokens
      * except [Token.EOF].
      */
+    @JvmField
     public val EMPTY_VOCABULARY: Vocabulary = VocabularyImpl(EMPTY_NAMES, EMPTY_NAMES, EMPTY_NAMES)
 
     /**

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATNDeserializationOptions.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATNDeserializationOptions.kt
@@ -1,13 +1,15 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package org.antlr.v4.kotlinruntime.atn
+
+import kotlin.jvm.JvmField
 
 /**
  * @author Sam Harwell
  */
 public open class ATNDeserializationOptions {
   public companion object {
+    @JvmField
     public val defaultOptions: ATNDeserializationOptions = ATNDeserializationOptions().also {
       it.makeReadOnly()
     }

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATNSerializer.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATNSerializer.kt
@@ -1,6 +1,5 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package org.antlr.v4.kotlinruntime.atn
 
 import com.strumenta.antlrkotlin.runtime.assert
@@ -18,6 +17,9 @@ import org.antlr.v4.kotlinruntime.misc.IntervalSet
  */
 public open class ATNSerializer(public var atn: ATN) {
   public companion object {
+    public fun getSerialized(atn: ATN): IntegerList =
+      ATNSerializer(atn).serialize()
+
     private fun serializeSets(data: IntegerList, sets: Collection<IntervalSet>) {
       val nSets = sets.size
       data.add(nSets)
@@ -49,9 +51,6 @@ public open class ATNSerializer(public var atn: ATN) {
         }
       }
     }
-
-    public fun getSerialized(atn: ATN): IntegerList =
-      ATNSerializer(atn).serialize()
   }
 
   private val data = IntegerList()

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATNSimulator.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATNSimulator.kt
@@ -1,12 +1,12 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package org.antlr.v4.kotlinruntime.atn
 
 import com.strumenta.antlrkotlin.runtime.IdentityHashMap
 import com.strumenta.antlrkotlin.runtime.synchronized
 import org.antlr.v4.kotlinruntime.dfa.DFA
 import org.antlr.v4.kotlinruntime.dfa.DFAState
+import kotlin.jvm.JvmField
 
 public abstract class ATNSimulator(
   public val atn: ATN,
@@ -38,6 +38,7 @@ public abstract class ATNSimulator(
     /**
      * Must distinguish between missing edge and edge we know leads nowhere.
      */
+    @JvmField
     public val ERROR: DFAState = DFAState(ATNConfigSet()).also {
       it.stateNumber = Int.MAX_VALUE
     }

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATNState.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATNState.kt
@@ -1,10 +1,10 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package org.antlr.v4.kotlinruntime.atn
 
 import com.strumenta.antlrkotlin.runtime.System
 import org.antlr.v4.kotlinruntime.misc.IntervalSet
+import kotlin.jvm.JvmField
 
 /**
  * The following images show the relation of states and
@@ -41,6 +41,7 @@ public abstract class ATNState {
     public const val PLUS_LOOP_BACK: Int = 11
     public const val LOOP_END: Int = 12
 
+    @JvmField
     public val serializationNames: Array<String> = arrayOf(
       "INVALID",
       "BASIC",

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/LexerActionExecutor.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/LexerActionExecutor.kt
@@ -1,6 +1,5 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package org.antlr.v4.kotlinruntime.atn
 
 import org.antlr.v4.kotlinruntime.CharStream

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ParserATNSimulator.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ParserATNSimulator.kt
@@ -1,6 +1,5 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package org.antlr.v4.kotlinruntime.atn
 
 import com.strumenta.antlrkotlin.runtime.BitSet
@@ -13,6 +12,7 @@ import org.antlr.v4.kotlinruntime.dfa.DFAState
 import org.antlr.v4.kotlinruntime.misc.DoubleKeyMap
 import org.antlr.v4.kotlinruntime.misc.Interval
 import org.antlr.v4.kotlinruntime.misc.IntervalSet
+import kotlin.jvm.JvmField
 
 /**
  * The embodiment of the adaptive LL(*), ALL(*), parsing strategy.
@@ -220,14 +220,22 @@ public open class ParserATNSimulator(
   sharedContextCache: PredictionContextCache,
 ) : ATNSimulator(atn, sharedContextCache) {
   public companion object {
+    @JvmField
     public var debug: Boolean = false
+
+    @JvmField
     public var trace_atn_sim: Boolean = false
+
+    @JvmField
     public var dfa_debug: Boolean = false
+
+    @JvmField
     public var retry_debug: Boolean = false
 
     /**
      * Just in case this optimization is bad, add an ENV variable to turn it off.
      */
+    @JvmField
     public val TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT: Boolean =
       getSafeEnv("TURN_OFF_LR_LOOP_ENTRY_BRANCH_OPT", "false").toBoolean()
 

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/PredictionContext.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/PredictionContext.kt
@@ -10,6 +10,7 @@ import org.antlr.v4.kotlinruntime.Recognizer
 import org.antlr.v4.kotlinruntime.RuleContext
 import org.antlr.v4.kotlinruntime.misc.DoubleKeyMap
 import org.antlr.v4.kotlinruntime.misc.MurmurHash
+import kotlin.jvm.JvmField
 
 @Suppress("EqualsOrHashCode", "MemberVisibilityCanBePrivate")
 public abstract class PredictionContext protected constructor(
@@ -723,6 +724,7 @@ public abstract class PredictionContext protected constructor(
     }
   }
 
+  @JvmField
   public val id: Int = globalNodeCount++
 
   /**

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/PredictionMode.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/PredictionMode.kt
@@ -12,7 +12,6 @@ import org.antlr.v4.kotlinruntime.misc.MurmurHash
  * utility methods for analyzing configuration sets for conflicts and/or
  * ambiguities.
  */
-@Suppress("MemberVisibilityCanBePrivate")
 public enum class PredictionMode {
   /**
    * The SLL(*) prediction mode. This prediction mode ignores the current

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/SemanticContext.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/SemanticContext.kt
@@ -1,6 +1,5 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package org.antlr.v4.kotlinruntime.atn
 
 import com.strumenta.antlrkotlin.runtime.Collections
@@ -8,7 +7,6 @@ import org.antlr.v4.kotlinruntime.Recognizer
 import org.antlr.v4.kotlinruntime.RuleContext
 import org.antlr.v4.kotlinruntime.atn.SemanticContext.*
 import org.antlr.v4.kotlinruntime.misc.MurmurHash
-import kotlin.jvm.JvmStatic
 
 /**
  * A tree structure used to record the semantic context in which

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/SingletonPredictionContext.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/SingletonPredictionContext.kt
@@ -1,6 +1,5 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package org.antlr.v4.kotlinruntime.atn
 
 import com.strumenta.antlrkotlin.runtime.assert

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/Transition.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/Transition.kt
@@ -1,10 +1,10 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package org.antlr.v4.kotlinruntime.atn
 
 import org.antlr.v4.kotlinruntime.misc.IntervalSet
 import kotlin.js.JsName
+import kotlin.jvm.JvmField
 
 /**
  * An ATN transition between any two ATN states.
@@ -36,6 +36,7 @@ public abstract class Transition protected constructor(public var target: ATNSta
     public const val WILDCARD: Int = 9
     public const val PRECEDENCE: Int = 10
 
+    @JvmField
     public val serializationNames: Array<String> = arrayOf(
       "INVALID",
       "EPSILON",

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/Interval.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/Interval.kt
@@ -2,6 +2,7 @@
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
 package org.antlr.v4.kotlinruntime.misc
 
+import kotlin.jvm.JvmField
 import kotlin.math.max
 import kotlin.math.min
 
@@ -12,8 +13,11 @@ import kotlin.math.min
 public class Interval(public var a: Int, public var b: Int) {
   public companion object {
     public const val INTERVAL_POOL_MAX_VALUE: Int = 1000
+
+    @JvmField
     public val INVALID: Interval = Interval(-1, -2)
 
+    @JvmField
     internal val cache = arrayOfNulls<Interval>(INTERVAL_POOL_MAX_VALUE + 1)
 
     /**

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/IntervalSet.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/IntervalSet.kt
@@ -6,6 +6,7 @@ import com.strumenta.antlrkotlin.runtime.ext.appendCodePoint
 import org.antlr.v4.kotlinruntime.Lexer
 import org.antlr.v4.kotlinruntime.Token
 import org.antlr.v4.kotlinruntime.Vocabulary
+import kotlin.jvm.JvmField
 
 /**
  * This class implements the [IntSet] backed by a sorted array of
@@ -17,14 +18,15 @@ import org.antlr.v4.kotlinruntime.Vocabulary
  * This class is able to represent sets containing any combination of values in
  * the range [Int.MIN_VALUE] to [Int.MAX_VALUE] (inclusive).
  */
-@Suppress("MemberVisibilityCanBePrivate", "LocalVariableName")
+@Suppress("LocalVariableName")
 public class IntervalSet : IntSet {
-  @Suppress("MemberVisibilityCanBePrivate")
   public companion object {
+    @JvmField
     public val COMPLETE_CHAR_SET: IntervalSet = of(Lexer.MIN_CHAR_VALUE, Lexer.MAX_CHAR_VALUE).also {
       it.isReadonly = true
     }
 
+    @JvmField
     public val EMPTY_SET: IntervalSet = IntervalSet().also {
       it.isReadonly = true
     }

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/ParseTreeWalker.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/ParseTreeWalker.kt
@@ -3,11 +3,11 @@
 package org.antlr.v4.kotlinruntime.tree
 
 import org.antlr.v4.kotlinruntime.ParserRuleContext
-import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmField
 
 public open class ParseTreeWalker {
   public companion object {
-    @JvmStatic
+    @JvmField
     public val DEFAULT: ParseTreeWalker = ParseTreeWalker()
   }
 


### PR DESCRIPTION
Annotations have been added by matching where the Java runtime uses fields.

Obviously that means the annotation has been applied to properties that **are not meant** to be overridden.