### PR TITLE
Remove the dependency on kotlin-reflect

### DIFF
--- a/antlr-kotlin-runtime/build.gradle.kts
+++ b/antlr-kotlin-runtime/build.gradle.kts
@@ -27,12 +27,6 @@ strumentaMultiplatform {
 
 kotlin {
   sourceSets {
-    commonMain {
-      dependencies {
-        implementation(kotlin("reflect"))
-      }
-    }
-
     commonTest {
       dependencies {
         implementation(kotlin("test"))


### PR DESCRIPTION
As noticed by @JesusMcCloud in #153, we depend on `kotlin-reflect` in the runtime, but we don't actually use it.