### PR TITLE
Cleanup the ParseTree hierarchy and open its functions

### DIFF
--- a/antlr-kotlin-benchmarks/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/benchmarks/mysql/MySQLErrorListener.kt
+++ b/antlr-kotlin-benchmarks/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/benchmarks/mysql/MySQLErrorListener.kt
@@ -106,8 +106,8 @@ public class MySQLErrorListener : BaseErrorListener() {
       // Walk up from generic rules to reach something that gives us more context, if needed.
       var context = parser.context
 
-      while (context?.parent != null && simpleRules.contains(context.ruleIndex)) {
-        context = context.parent as ParserRuleContext?
+      while (context?.getParent() != null && simpleRules.contains(context.ruleIndex)) {
+        context = context.getParent()
       }
 
       // Try to find the expected input by examining the current parser context and

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/BailErrorStrategy.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/BailErrorStrategy.kt
@@ -46,7 +46,7 @@ public class BailErrorStrategy : DefaultErrorStrategy() {
 
     while (context != null) {
       context.exception = e
-      context = context.readParent()
+      context = context.getParent()
     }
 
     throw ParseCancellationException(e)
@@ -63,7 +63,7 @@ public class BailErrorStrategy : DefaultErrorStrategy() {
 
     while (context != null) {
       context.exception = e
-      context = context.readParent()
+      context = context.getParent()
     }
 
     throw ParseCancellationException(e)

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/DefaultErrorStrategy.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/DefaultErrorStrategy.kt
@@ -735,7 +735,7 @@ public open class DefaultErrorStrategy : ANTLRErrorStrategy {
       val rt = invokingState!!.transition(0) as RuleTransition
       val follow = atn.nextTokens(rt.followState)
       recoverSet.addAll(follow)
-      ctx = ctx.readParent()
+      ctx = ctx.getParent()
     }
 
     recoverSet.remove(Token.EPSILON)

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Parser.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Parser.kt
@@ -49,8 +49,10 @@ public abstract class Parser(input: TokenStream) : Recognizer<Token, ParserATNSi
     }
 
     override fun exitEveryRule(ctx: ParserRuleContext) {
-      if (ctx.children is ArrayList<*>) {
-        (ctx.children as ArrayList<*>).trimToSize()
+      val children = ctx.children
+
+      if (children is ArrayList<*>) {
+        children.trimToSize()
       }
     }
   }

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Parser.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Parser.kt
@@ -584,7 +584,7 @@ public abstract class Parser(input: TokenStream) : Recognizer<Token, ParserATNSi
     ErrorNodeImpl(t)
 
   protected open fun addContextToParseTree() {
-    val parent = context!!.readParent()
+    val parent = context!!.getParent()
 
     // Add current context to parent if we have a parent
     parent?.addChild(context!!)
@@ -620,7 +620,7 @@ public abstract class Parser(input: TokenStream) : Recognizer<Token, ParserATNSi
     // Trigger event on context, before it reverts to parent
     triggerExitRuleEvent()
     state = context!!.invokingState
-    context = context!!.readParent()
+    context = context!!.getParent()
   }
 
   public fun enterOuterAlt(localctx: ParserRuleContext, altNum: Int) {
@@ -629,7 +629,7 @@ public abstract class Parser(input: TokenStream) : Recognizer<Token, ParserATNSi
     // If we have new localctx, make sure we replace existing ctx
     // that is previous child of parse tree
     if (buildParseTree && context !== localctx) {
-      val parent = context!!.readParent()
+      val parent = context!!.getParent()
 
       if (parent != null) {
         parent.removeLastChild()
@@ -657,7 +657,7 @@ public abstract class Parser(input: TokenStream) : Recognizer<Token, ParserATNSi
    */
   public open fun pushNewRecursionContext(localctx: ParserRuleContext, state: Int, ruleIndex: Int) {
     val previous = context
-    previous!!.assignParent(localctx)
+    previous!!.setParent(localctx)
     previous.invokingState = state
     previous.stop = _input.LT(-1)
 
@@ -683,14 +683,14 @@ public abstract class Parser(input: TokenStream) : Recognizer<Token, ParserATNSi
     if (parseListeners.isNotEmpty()) {
       while (context !== _parentctx) {
         triggerExitRuleEvent()
-        context = context!!.readParent()
+        context = context!!.getParent()
       }
     } else {
       context = _parentctx
     }
 
     // Hook into tree
-    retCtx!!.assignParent(_parentctx)
+    retCtx!!.setParent(_parentctx)
 
     if (buildParseTree && _parentctx != null) {
       // Add return ctx into invoking rule's tree
@@ -706,7 +706,7 @@ public abstract class Parser(input: TokenStream) : Recognizer<Token, ParserATNSi
         return p
       }
 
-      p = p.readParent()
+      p = p.getParent()
     }
 
     return null
@@ -757,7 +757,7 @@ public abstract class Parser(input: TokenStream) : Recognizer<Token, ParserATNSi
         return true
       }
 
-      ctx = ctx.readParent()
+      ctx = ctx.getParent()
     }
 
     return following.contains(Token.EPSILON) && symbol == Token.EOF
@@ -795,7 +795,7 @@ public abstract class Parser(input: TokenStream) : Recognizer<Token, ParserATNSi
         stack.add(ruleNames[ruleIndex])
       }
 
-      p = p.readParent()
+      p = p.getParent()
     }
 
     return stack

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/RuleContext.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/RuleContext.kt
@@ -8,6 +8,7 @@ import org.antlr.v4.kotlinruntime.tree.ParseTree
 import org.antlr.v4.kotlinruntime.tree.ParseTreeVisitor
 import org.antlr.v4.kotlinruntime.tree.RuleNode
 import org.antlr.v4.kotlinruntime.tree.Trees
+import kotlin.jvm.JvmField
 
 /**
  * A rule context is a record of a single rule invocation.
@@ -68,7 +69,8 @@ public open class RuleContext : RuleNode {
   /**
    * What context invoked this rule?
    */
-  public var parent: RuleContext? = null
+  @JvmField
+  protected var parent: RuleContext? = null
 
   /**
    * What state invoked the rule associated with this context?
@@ -77,6 +79,7 @@ public open class RuleContext : RuleNode {
    * If [parent] is `null`, this should be `-1` as this context
    * object represents the start rule.
    */
+  @JvmField
   public var invokingState: Int = -1
 
   /**
@@ -151,14 +154,14 @@ public open class RuleContext : RuleNode {
     this.invokingState = invokingState
   }
 
-  override fun readParent(): RuleContext? =
+  override fun getParent(): RuleContext? =
     parent
 
-  override fun assignParent(value: RuleContext?) {
+  override fun setParent(value: RuleContext?) {
     parent = value
   }
 
-  public fun depth(): Int {
+  public open fun depth(): Int {
     var n = 0
     var p: RuleContext? = this
 
@@ -191,7 +194,7 @@ public open class RuleContext : RuleNode {
    *
    * Print just a node if this is a leaf.
    */
-  public fun toStringTree(ruleNames: List<String>?): String =
+  public open fun toStringTree(ruleNames: List<String>?): String =
     Trees.toStringTree(this, ruleNames)
 
   override fun toStringTree(): String =
@@ -201,7 +204,7 @@ public open class RuleContext : RuleNode {
     toString(ruleNames = null, stop = null)
 
   // recog null unless ParserRuleContext, in which case we use subclass toString(...)
-  public fun toString(recog: Recognizer<*, *>?, stop: RuleContext = ParserRuleContext.EMPTY): String {
+  public open fun toString(recog: Recognizer<*, *>?, stop: RuleContext = ParserRuleContext.EMPTY): String {
     val ruleNames = recog?.ruleNames
     val ruleNamesList = if (ruleNames != null) {
       listOf(*ruleNames)
@@ -212,7 +215,7 @@ public open class RuleContext : RuleNode {
     return toString(ruleNamesList, stop)
   }
 
-  public fun toString(ruleNames: List<String>?, stop: RuleContext? = null): String {
+  public open fun toString(ruleNames: List<String>?, stop: RuleContext? = null): String {
     val buf = StringBuilder()
     var p: RuleContext? = this
     buf.append("[")

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Token.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/Token.kt
@@ -117,10 +117,8 @@ public interface Token {
   public fun startPoint(): Point =
     Point(line, charPositionInLine)
 
-  public fun endPoint(): Point? =
-    if (text == null) {
-      null
-    } else {
-      Point(line, charPositionInLine).advance(text!!)
-    }
+  public fun endPoint(): Point? {
+    val text = this.text ?: return null
+    return Point(line, charPositionInLine).advance(text)
+  }
 }

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATN.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/ATN.kt
@@ -178,7 +178,7 @@ public class ATN(public val grammarType: ATNType, public val maxTokenType: Int) 
       following = nextTokens(rt.followState)
       expected.addAll(following)
       expected.remove(Token.EPSILON)
-      ctx = ctx.readParent()
+      ctx = ctx.getParent()
     }
 
     if (following.contains(Token.EPSILON)) {

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/PredictionContext.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/PredictionContext.kt
@@ -64,12 +64,12 @@ public abstract class PredictionContext protected constructor(
 
       // If we are in RuleContext of start rule, s, then PredictionContext
       // is EMPTY. Nobody called us. (if we are empty, return empty)
-      if (tempOuterContext.parent == null || tempOuterContext === ParserRuleContext.EMPTY) {
+      if (tempOuterContext.getParent() == null || tempOuterContext === ParserRuleContext.EMPTY) {
         return EmptyPredictionContext
       }
 
       // If we have a parent, convert it to a PredictionContext graph
-      val parent = fromRuleContext(atn, tempOuterContext.readParent())
+      val parent = fromRuleContext(atn, tempOuterContext.getParent())
       val state = atn.states[tempOuterContext.invokingState]
       val transition = state!!.transition(0) as RuleTransition
       return SingletonPredictionContext.create(parent, transition.followState.stateNumber)

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/IterativeParseTreeWalker.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/IterativeParseTreeWalker.kt
@@ -57,7 +57,11 @@ public open class IterativeParseTreeWalker : ParseTreeWalker() {
         // No next, sibling, so move up
         currentNode = nodeStack.removeFirst()
         currentIndex = indexStack.pop()
-      } while (currentNode != null)
+
+        // The original condition was 'currentNode != null',
+        // but since nodeStack.removeFirst() throws if there
+        // is no element, the condition is always true
+      } while (true)
     }
   }
 }

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/ParseTree.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/ParseTree.kt
@@ -23,6 +23,12 @@ public interface ParseTree : SyntaxTree {
    */
   public val text: String
 
+  // Narrows down the return type to ParseTree
+  override fun getParent(): ParseTree?
+
+  // Narrows down the return type to ParseTree
+  override fun getChild(i: Int): ParseTree?
+
   /**
    * Set the parent for this node.
    *
@@ -39,7 +45,7 @@ public interface ParseTree : SyntaxTree {
    *
    * @since 4.7
    */
-  public fun assignParent(value: RuleContext?)
+  public fun setParent(value: RuleContext?)
 
   /**
    * The [ParseTreeVisitor] needs a double dispatch method.
@@ -51,10 +57,4 @@ public interface ParseTree : SyntaxTree {
    * based upon the parser.
    */
   public fun toStringTree(parser: Parser): String
-
-  // Narrows down the return type to ParseTree
-  override fun readParent(): ParseTree?
-
-  // Narrows down the return type to ParseTree
-  override fun getChild(i: Int): ParseTree?
 }

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/TerminalNodeImpl.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/TerminalNodeImpl.kt
@@ -25,10 +25,10 @@ public open class TerminalNodeImpl(override var symbol: Token) : TerminalNode {
       return Interval(tokenIndex, tokenIndex)
     }
 
-  override fun readParent(): ParseTree? =
+  override fun getParent(): ParseTree? =
     parent
 
-  override fun assignParent(value: RuleContext?) {
+  override fun setParent(value: RuleContext?) {
     parent = value
   }
 

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/Tree.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/Tree.kt
@@ -30,7 +30,7 @@ public interface Tree {
    *
    * If the return value is `null`, then this node is the root of the tree.
    */
-  public fun readParent(): Tree?
+  public fun getParent(): Tree?
 
   /**
    * If there are children, get the `i`th value indexed from `0`.

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/Trees.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/tree/Trees.kt
@@ -125,17 +125,17 @@ public object Trees {
    * @since 4.5.1
    */
   public fun getAncestors(t: Tree): List<Tree> {
-    if (t.readParent() == null) {
+    if (t.getParent() == null) {
       return emptyList()
     }
 
     val ancestors = ArrayList<Tree>()
-    var t1 = t.readParent()
+    var t1 = t.getParent()
 
     while (t1 != null) {
       // Insert at start
       ancestors.add(0, t1)
-      t1 = t1.readParent()
+      t1 = t1.getParent()
     }
 
     return ancestors
@@ -147,11 +147,11 @@ public object Trees {
    * @since 4.5.1
    */
   public fun isAncestorOf(t: Tree?, u: Tree?): Boolean {
-    if (t == null || u == null || t.readParent() == null) {
+    if (t == null || u == null || t.getParent() == null) {
       return false
     }
 
-    var p = u.readParent()
+    var p = u.getParent()
 
     while (p != null) {
       // Keep reference equality!
@@ -159,7 +159,7 @@ public object Trees {
         return true
       }
 
-      p = p.readParent()
+      p = p.getParent()
     }
 
     return false


### PR DESCRIPTION
For the historical reason that `RuleContext.parent` wasn't marked with `@JvmField`, the two original Java `getParent()` and `setParent()` functions had to be renamed to `readParent()` and `assignParent()` to avoid a collission with the JVM-generated getter and setter for the `parent` property.

This change encapsulates the `parent` field into the `RuleContext` hierarchy - marking it with `@JvmField` and hiding it from the outer world - and renames the get/set functions to their original names.

`ParserRuleContext`'s functions have also been opened.
