### PR TITLE
Implement IdentityHashMap for the JS target

### DIFF
--- a/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/BitSet.kt
+++ b/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/BitSet.kt
@@ -7,7 +7,7 @@ import org.antlr.v4.kotlinruntime.misc.MurmurHash
 
 @Suppress("SimplifyBooleanWithConstants")
 public actual class BitSet actual constructor(size: Int) {
-  private val bits = newArray(size)
+  private val bits = newArray<Boolean>(size)
 
   init {
     require(size >= 0) {
@@ -158,8 +158,4 @@ public actual class BitSet actual constructor(size: Int) {
 
     return -1
   }
-
-  @Suppress("UNUSED_PARAMETER")
-  private fun newArray(size: Int): Array<Boolean> =
-    js("Array(size)").unsafeCast<Array<Boolean>>()
 }

--- a/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityEntriesView.kt
+++ b/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityEntriesView.kt
@@ -1,0 +1,86 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package com.strumenta.antlrkotlin.runtime
+
+import js.collections.JsMap
+import kotlin.collections.MutableMap.MutableEntry as ME
+
+internal class IdentityEntriesView<K, V>(private val jsMap: JsMap<K, V>) : AbstractMutableSet<ME<K, V>>() {
+  override val size: Int
+    get() = jsMap.size
+
+  override fun isEmpty(): Boolean =
+    jsMap.size == 0
+
+  override fun clear(): Unit =
+    jsMap.clear()
+
+  override fun add(element: ME<K, V>): Boolean =
+    throw UnsupportedOperationException("Adding is not supported on entries")
+
+  override fun remove(element: ME<K, V>): Boolean {
+    val (key, value) = element
+    return remove(key, value)
+  }
+
+  override fun removeAll(elements: Collection<ME<K, V>>): Boolean {
+    var removed = false
+
+    for (element in elements) {
+      removed = remove(element) || removed
+    }
+
+    return removed
+  }
+
+  override fun contains(element: ME<K, V>): Boolean {
+    val k = undefinedToNull(element.key)
+    return jsMap.has(k) && jsMap[k] === element.value
+  }
+
+  override fun iterator(): MutableIterator<ME<K, V>> {
+    val iterator = jsMap.iterator()
+    return object : MutableIterator<ME<K, V>> {
+      var lastEntry: IdentityEntriesView<K, V>.IdentityEntry? = null
+
+      override fun hasNext(): Boolean =
+        iterator.hasNext()
+
+      override fun next(): ME<K, V> {
+        val (key, value) = iterator.next()
+        val entry = IdentityEntry(key, value)
+        lastEntry = entry
+        return entry
+      }
+
+      override fun remove() {
+        val lastEntry = checkNotNull(this.lastEntry)
+        remove(lastEntry.key, lastEntry.value)
+      }
+    }
+  }
+
+  private fun remove(key: K, value: V): Boolean {
+    val k = undefinedToNull(key)
+
+    if (jsMap.has(k)) {
+      // IMPORTANT: notice that we use reference/strict equality
+      if (jsMap[k] === value) {
+        return jsMap.delete(k)
+      }
+    }
+
+    return false
+  }
+
+  private inner class IdentityEntry(override val key: K, override var value: V) : ME<K, V> {
+    override fun setValue(newValue: V): V {
+      val oldValue = value
+      check(oldValue === jsMap[key])
+
+      jsMap[key] = newValue
+      value = newValue
+      return oldValue
+    }
+  }
+}

--- a/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
+++ b/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
@@ -1,0 +1,78 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package com.strumenta.antlrkotlin.runtime
+
+import js.collections.JsMap
+import kotlin.collections.MutableMap.MutableEntry as ME
+
+public actual class IdentityHashMap<K, V> : MutableMap<K, V> {
+  private val jsMap = JsMap<K, V>()
+
+  actual override val size: Int
+    get() = jsMap.size
+
+  actual override val keys: MutableSet<K>
+    get() = IdentityKeysView(this)
+
+  actual override val values: MutableCollection<V>
+    get() = IdentityValuesView(this)
+
+  actual override val entries: MutableSet<ME<K, V>>
+    get() = IdentityEntriesView(jsMap)
+
+  actual override fun isEmpty(): Boolean =
+    jsMap.size == 0
+
+  actual override fun clear(): Unit =
+    jsMap.clear()
+
+  actual override fun get(key: K): V? {
+    val k = undefinedToNull(key)
+    return undefinedToNull(jsMap[k])
+  }
+
+  actual override fun put(key: K, value: V): V? {
+    val k = undefinedToNull(key)
+    val previousValue = jsMap[k]
+    jsMap[k] = value
+    return undefinedToNull(previousValue)
+  }
+
+  actual override fun remove(key: K): V? {
+    val k = undefinedToNull(key)
+    val removedValue = jsMap[k]
+    jsMap.delete(k)
+    return undefinedToNull(removedValue)
+  }
+
+  actual override fun putAll(from: Map<out K, V>) {
+    for ((key, value) in from) {
+      val k = undefinedToNull(key)
+      jsMap[k] = value
+    }
+  }
+
+  actual override fun containsKey(key: K): Boolean {
+    val k = undefinedToNull(key)
+    return jsMap.has(k)
+  }
+
+  actual override fun containsValue(value: V): Boolean {
+    for (v in jsMap.values()) {
+      // IMPORTANT: notice that we use reference/strict equality
+      if (v === value) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  /**
+   * Same as `remove(key)`, but returns a boolean value.
+   */
+  internal fun removeBoolean(key: K): Boolean {
+    val k = undefinedToNull(key)
+    return jsMap.delete(k)
+  }
+}

--- a/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityKeysView.kt
+++ b/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityKeysView.kt
@@ -1,0 +1,47 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package com.strumenta.antlrkotlin.runtime
+
+internal class IdentityKeysView<K>(private val map: IdentityHashMap<K, *>) : AbstractMutableSet<K>() {
+  override val size: Int
+    get() = map.size
+
+  override fun isEmpty(): Boolean =
+    map.isEmpty()
+
+  override fun clear(): Unit =
+    map.clear()
+
+  override fun contains(element: K): Boolean =
+    map.containsKey(element)
+
+  override fun add(element: K): Boolean =
+    throw UnsupportedOperationException("Adding is not supported on keys")
+
+  override fun remove(element: K): Boolean =
+    map.removeBoolean(element)
+
+  override fun removeAll(elements: Collection<K>): Boolean {
+    var removed = false
+
+    for (element in elements) {
+      removed = remove(element) || removed
+    }
+
+    return removed
+  }
+
+  override fun iterator(): MutableIterator<K> {
+    val entriesIterator = map.entries.iterator()
+    return object : MutableIterator<K> {
+      override fun hasNext(): Boolean =
+        entriesIterator.hasNext()
+
+      override fun next(): K =
+        entriesIterator.next().key
+
+      override fun remove(): Unit =
+        entriesIterator.remove()
+    }
+  }
+}

--- a/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityValuesView.kt
+++ b/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityValuesView.kt
@@ -1,0 +1,58 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package com.strumenta.antlrkotlin.runtime
+
+internal class IdentityValuesView<V>(private val map: IdentityHashMap<*, V>) : AbstractMutableCollection<V>() {
+  override val size: Int
+    get() = map.size
+
+  override fun isEmpty(): Boolean =
+    map.isEmpty()
+
+  override fun clear(): Unit =
+    map.clear()
+
+  override fun add(element: V): Boolean =
+    throw UnsupportedOperationException("Adding is not supported on values")
+
+  override fun remove(element: V): Boolean {
+    val iterator = iterator()
+
+    while (iterator.hasNext()) {
+      // IMPORTANT: notice that we use reference/strict equality
+      if (iterator.next() === element) {
+        iterator.remove()
+        return true
+      }
+    }
+
+    return false
+  }
+
+  override fun removeAll(elements: Collection<V>): Boolean {
+    var removed = false
+
+    for (element in elements) {
+      removed = remove(element) || removed
+    }
+
+    return removed
+  }
+
+  override operator fun contains(element: V): Boolean =
+    map.containsValue(element)
+
+  override operator fun iterator(): MutableIterator<V> {
+    val entriesIterator = map.entries.iterator()
+    return object : MutableIterator<V> {
+      override fun hasNext(): Boolean =
+        entriesIterator.hasNext()
+
+      override fun next(): V =
+        entriesIterator.next().value
+
+      override fun remove(): Unit =
+        entriesIterator.remove()
+    }
+  }
+}

--- a/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/JsUtils.kt
+++ b/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/JsUtils.kt
@@ -1,6 +1,22 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+@file:Suppress("NOTHING_TO_INLINE", "UnsafeCastFromDynamic")
+
 package com.strumenta.antlrkotlin.runtime
+
+/**
+ * Normalizes potentially `undefined` values to `null`.
+ */
+internal inline fun <T> undefinedToNull(value: T): T =
+  if (value === js("undefined")) js("null") else value
+
+/**
+ * Creates a new generic array with an initial [size],
+ * without requiring the initialization of the elements.
+ */
+@Suppress("UNUSED_PARAMETER")
+internal inline fun <T> newArray(size: Int): Array<T> =
+  js("Array(size)")
 
 /**
  * Returns whether we are running on Node.js, or not.
@@ -16,4 +32,4 @@ internal fun isNodeJs(): Boolean =
       && window.process.versions != null
       && window.process.versions.node != null)
     """
-  ).unsafeCast<Boolean>()
+  )

--- a/antlr-kotlin-runtime/src/jsTest/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMapTests.kt
+++ b/antlr-kotlin-runtime/src/jsTest/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMapTests.kt
@@ -1,0 +1,169 @@
+// Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
+// Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
+package com.strumenta.antlrkotlin.runtime
+
+import kotlin.collections.MutableMap.MutableEntry
+import kotlin.test.*
+
+class IdentityHashMapTests {
+  @Test
+  fun insertions() {
+    val imap = IdentityHashMap<Any, String>()
+    var prev = imap.put("one", "two")
+
+    assertNull(prev)
+    assertEquals(1, imap.size)
+    assertEquals("two", imap["one"])
+
+    prev = imap.put("one", "three")
+    assertEquals(1, imap.size)
+    assertEquals("two", prev)
+    assertEquals("three", imap["one"])
+
+    imap.clear()
+    assertTrue(imap.isEmpty())
+
+    val a = A("one")
+    prev = imap.put(a, "two")
+    assertNull(prev)
+
+    val b = B("one")
+    prev = imap.remove(b)
+    assertNull(prev)
+
+    prev = imap.remove(a)
+    assertEquals("two", prev)
+  }
+
+  @Test
+  fun containsValue() {
+    val imap = IdentityHashMap<String, A>()
+    val a = A("one")
+    imap["one"] = A("one")
+    imap["two"] = a
+    imap["three"] = A("one")
+
+    assertFalse(imap.containsValue(A("one")))
+    assertTrue(imap.containsValue(a))
+  }
+
+  @Test
+  fun keysIterator() {
+    val imap = IdentityHashMap<Any, String>()
+    val one = A("one")
+    imap[one] = "value-one"
+    imap["two"] = "value-two"
+
+    val keys = imap.keys
+    val iterator = keys.iterator()
+    assertTrue(iterator.hasNext())
+    assertSame(one, iterator.next())
+    assertEquals("two", iterator.next())
+    assertFalse(iterator.hasNext())
+
+    iterator.remove()
+    assertEquals(1, imap.size)
+    assertEquals("value-one", imap[one])
+
+    assertFailsWith(UnsupportedOperationException::class) {
+      keys.add("three")
+    }
+
+    assertFailsWith(UnsupportedOperationException::class) {
+      keys.addAll(listOf("four", "five"))
+    }
+  }
+
+  @Test
+  fun missingKey() {
+    val imap = IdentityHashMap<Any?, String>()
+    assertSame(null, imap["missing"])
+  }
+
+  @Test
+  fun nullKeys() {
+    val imap = IdentityHashMap<Any?, A>()
+    imap[null] = A("one")
+    assertEquals(1, imap.size)
+
+    val two = A("two")
+    imap[null] = two
+    assertEquals(1, imap.size)
+    assertSame(two, imap[null])
+
+    val entries = imap.entries
+    assertTrue(entries.contains(TestEntry(null, two)))
+    assertFalse(entries.contains(TestEntry(null, A("two"))))
+
+    val eiter = entries.iterator()
+    assertTrue(eiter.hasNext())
+
+    val next = eiter.next()
+    assertSame(null, next.key)
+    assertSame(two, next.value)
+
+    val newValue = A("new")
+    next.setValue(newValue)
+    assertSame(newValue, imap[null])
+
+    eiter.remove()
+    assertTrue(imap.isEmpty())
+  }
+
+  @Test
+  fun nullValues() {
+    val imap = IdentityHashMap<Int, String?>()
+    imap[0] = "zero"
+    imap[1] = null
+    imap[2] = null
+
+    assertEquals(3, imap.size)
+    assertEquals("zero", imap[0])
+    assertSame(null, imap[1])
+    assertSame(null, imap[2])
+  }
+
+  @Test
+  fun removeAll() {
+    val imap = IdentityHashMap<Int, String>()
+    imap[0] = "zero"
+    imap[1] = "one"
+    imap[2] = "two"
+    imap[10] = "ten"
+    imap[20] = "twenty"
+
+    assertEquals(5, imap.size)
+
+    val keys = imap.keys
+    assertFalse(keys.removeAll(listOf(-1, 11)))
+    assertEquals(5, imap.size)
+
+    assertTrue(keys.removeAll(listOf(1, 15, 19)))
+    assertEquals(4, imap.size)
+  }
+
+  interface S {
+    val s: String
+  }
+
+  class A(override val s: String) : S {
+    override fun equals(other: Any?): Boolean =
+      other is S && s == other.s
+
+    override fun hashCode(): Int =
+      s.hashCode()
+  }
+
+  class B(override val s: String) : S {
+    override fun equals(other: Any?): Boolean =
+      other is S && s == other.s
+
+    override fun hashCode(): Int =
+      s.hashCode()
+  }
+
+  class TestEntry<K, V>(override val key: K, override val value: V) : MutableEntry<K, V> {
+    override fun setValue(newValue: V): V =
+      throw UnsupportedOperationException()
+  }
+}

--- a/antlr-kotlin-runtime/src/jsTest/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMapTests.kt
+++ b/antlr-kotlin-runtime/src/jsTest/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMapTests.kt
@@ -33,6 +33,22 @@ class IdentityHashMapTests {
 
     prev = imap.remove(a)
     assertEquals("two", prev)
+    assertTrue(imap.isEmpty())
+
+    val one = A("same")
+    val two = A("same")
+    val three = B("same")
+    assertEquals(one, two)
+    assertEquals<Any>(two, three)
+
+    imap[one] = "one"
+    imap[two] = "two"
+    imap[three] = "three"
+
+    assertEquals(3, imap.size)
+    assertEquals("one", imap[one])
+    assertEquals("two", imap[two])
+    assertEquals("three", imap[three])
   }
 
   @Test

--- a/antlr-kotlin-runtime/src/jvmMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
+++ b/antlr-kotlin-runtime/src/jvmMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
@@ -1,6 +1,5 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package com.strumenta.antlrkotlin.runtime
 
 import java.util.IdentityHashMap as JavaIdentityHashMap

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
@@ -1,6 +1,5 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package com.strumenta.antlrkotlin.runtime
 
 // TODO(Edoardo): implement real identity comparison

--- a/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
+++ b/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
@@ -1,8 +1,6 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package com.strumenta.antlrkotlin.runtime
 
-// Note(Edoardo): this is implemented as an HashMap in the JS target,
-//  so let's keep it as it is
+// TODO(Edoardo): implement real identity comparison
 public actual typealias IdentityHashMap<K, V> = HashMap<K, V>


### PR DESCRIPTION
Finally managed to implement a proper identity map for K/JS, using the ES2015 `Map` as backing store.

WASM and Native are more complex, and less used, so they'll have to wait longer.  
And I'm not even sure it's possible in WASM.

The next step (another PR) is moving `CopyOnWriteArrayList`, `IdentityHashMap` and `WeakHashMap` to be `internal`, to avoid consumers using them and having to deal with unexpected results.