### PR TITLE
Make more declarations internal

### DIFF
--- a/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/Assert.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/Assert.kt
@@ -10,7 +10,7 @@ import kotlin.contracts.contract
  */
 @OptIn(ExperimentalContracts::class)
 @Suppress("NOTHING_TO_INLINE", "KotlinRedundantDiagnosticSuppress")
-public inline fun assert(condition: Boolean, message: String? = null) {
+internal inline fun assert(condition: Boolean, message: String? = null) {
   contract {
     returns() implies condition
   }

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/CodePoint.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/CodePoint.kt
@@ -11,14 +11,14 @@ internal const val MIN_LOW_SURROGATE: Int = 0xDC00
 internal const val HIGH_SURROGATE_ENCODE_OFFSET: Int =
   (MIN_HIGH_SURROGATE - (MIN_SUPPLEMENTARY_CODE_POINT_ ushr 10))
 
-public fun isBmpCodePoint(codePoint: Int): Boolean =
+internal inline fun isBmpCodePoint(codePoint: Int): Boolean =
   codePoint ushr 16 == 0
 
-public fun highSurrogate(codePoint: Int): Char =
+internal inline fun highSurrogate(codePoint: Int): Char =
   ((codePoint ushr 10) + HIGH_SURROGATE_ENCODE_OFFSET).toChar()
 
-public fun lowSurrogate(codePoint: Int): Char =
+internal inline fun lowSurrogate(codePoint: Int): Char =
   ((codePoint and 0x3FF) + MIN_LOW_SURROGATE).toChar()
 
-public fun isValidCodePoint(codePoint: Int): Boolean =
+internal inline fun isValidCodePoint(codePoint: Int): Boolean =
   codePoint in 0..MAX_CODE_POINT_

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/Collections.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/Collections.kt
@@ -2,10 +2,10 @@
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
 package com.strumenta.antlrkotlin.runtime
 
-public object Collections {
-  public fun <T : Comparable<T>> min(collection: Collection<T>): T =
+internal object Collections {
+  fun <T : Comparable<T>> min(collection: Collection<T>): T =
     collection.minOrNull() ?: throw NoSuchElementException()
 
-  public fun <T : Comparable<T>> max(collection: Collection<T>): T =
+  fun <T : Comparable<T>> max(collection: Collection<T>): T =
     collection.maxOrNull() ?: throw NoSuchElementException()
 }

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
@@ -2,9 +2,9 @@
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
 package com.strumenta.antlrkotlin.runtime
 
-public expect class CopyOnWriteArrayList<E>() : MutableList<E> {
+internal expect class CopyOnWriteArrayList<E>() : MutableList<E> {
   // Convenience constructor to avoid initializing with mutable state
-  public constructor(elements: Collection<E>)
+  constructor(elements: Collection<E>)
 
   override val size: Int
   override fun contains(element: E): Boolean

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
@@ -2,7 +2,7 @@
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
 package com.strumenta.antlrkotlin.runtime
 
-public expect class IdentityHashMap<K, V>() : MutableMap<K, V> {
+internal expect class IdentityHashMap<K, V>() : MutableMap<K, V> {
   override val size: Int
   override val entries: MutableSet<MutableMap.MutableEntry<K, V>>
   override val keys: MutableSet<K>

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -7,4 +7,4 @@ package com.strumenta.antlrkotlin.runtime
 //  Also, how are we going to use the "lock" parameter?
 //  Probably it makes sense to just tell consumers the
 //  Kotlin Native implementation is not thread safe.
-public expect inline fun <R> synchronized(lock: Any, block: () -> R): R
+internal expect inline fun <R> synchronized(lock: Any, block: () -> R): R

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
@@ -2,7 +2,7 @@
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
 package com.strumenta.antlrkotlin.runtime
 
-public expect class WeakHashMap<K, V>() : MutableMap<K, V> {
+internal expect class WeakHashMap<K, V>() : MutableMap<K, V> {
   override val size: Int
   override val entries: MutableSet<MutableMap.MutableEntry<K, V>>
   override val keys: MutableSet<K>

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/PredictionContext.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/PredictionContext.kt
@@ -635,7 +635,7 @@ public abstract class PredictionContext protected constructor(
     public fun getCachedContext(
       context: PredictionContext,
       contextCache: PredictionContextCache,
-      visited: IdentityHashMap<PredictionContext, PredictionContext>,
+      visited: MutableMap<PredictionContext, PredictionContext>,
     ): PredictionContext {
       if (context.isEmpty) {
         return context

--- a/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
+++ b/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
@@ -3,4 +3,5 @@
 package com.strumenta.antlrkotlin.runtime
 
 // Note(Edoardo): JS is single threaded, so a normal list is good enough
-public actual typealias CopyOnWriteArrayList<E> = ArrayList<E>
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+internal actual typealias CopyOnWriteArrayList<E> = ArrayList<E>

--- a/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -8,7 +8,7 @@ import kotlin.contracts.contract
 
 // Not necessary for JavaScript. Single threaded.
 @OptIn(ExperimentalContracts::class)
-public actual inline fun <R> synchronized(lock: Any, block: () -> R): R {
+internal actual inline fun <R> synchronized(lock: Any, block: () -> R): R {
   contract {
     callsInPlace(block, InvocationKind.EXACTLY_ONCE)
   }

--- a/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
+++ b/antlr-kotlin-runtime/src/jsAndWasmSharedMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
@@ -1,8 +1,8 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package com.strumenta.antlrkotlin.runtime
 
 // Note(Edoardo): this is implemented as an HashMap in the JS target,
 //  so let's keep it as it is
-public actual typealias WeakHashMap<K, V> = HashMap<K, V>
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+internal actual typealias WeakHashMap<K, V> = HashMap<K, V>

--- a/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
+++ b/antlr-kotlin-runtime/src/jsMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
@@ -5,7 +5,7 @@ package com.strumenta.antlrkotlin.runtime
 import js.collections.JsMap
 import kotlin.collections.MutableMap.MutableEntry as ME
 
-public actual class IdentityHashMap<K, V> : MutableMap<K, V> {
+internal actual class IdentityHashMap<K, V> : MutableMap<K, V> {
   private val jsMap = JsMap<K, V>()
 
   actual override val size: Int

--- a/antlr-kotlin-runtime/src/jvmMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
+++ b/antlr-kotlin-runtime/src/jvmMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
@@ -2,4 +2,5 @@
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
 package com.strumenta.antlrkotlin.runtime
 
-public actual typealias CopyOnWriteArrayList<E> = java.util.concurrent.CopyOnWriteArrayList<E>
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+internal actual typealias CopyOnWriteArrayList<E> = java.util.concurrent.CopyOnWriteArrayList<E>

--- a/antlr-kotlin-runtime/src/jvmMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
+++ b/antlr-kotlin-runtime/src/jvmMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
@@ -4,4 +4,5 @@ package com.strumenta.antlrkotlin.runtime
 
 import java.util.IdentityHashMap as JavaIdentityHashMap
 
-public actual typealias IdentityHashMap<K, V> = JavaIdentityHashMap<K, V>
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+internal actual typealias IdentityHashMap<K, V> = JavaIdentityHashMap<K, V>

--- a/antlr-kotlin-runtime/src/jvmMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/antlr-kotlin-runtime/src/jvmMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -2,5 +2,5 @@
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
 package com.strumenta.antlrkotlin.runtime
 
-public actual inline fun <R> synchronized(lock: Any, block: () -> R): R =
+internal actual inline fun <R> synchronized(lock: Any, block: () -> R): R =
   kotlin.synchronized(lock, block)

--- a/antlr-kotlin-runtime/src/jvmMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
+++ b/antlr-kotlin-runtime/src/jvmMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
@@ -1,8 +1,8 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package com.strumenta.antlrkotlin.runtime
 
 import java.util.WeakHashMap as JavaWeakHashMap
 
-public actual typealias WeakHashMap<K, V> = JavaWeakHashMap<K, V>
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+internal actual typealias WeakHashMap<K, V> = JavaWeakHashMap<K, V>

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
@@ -3,4 +3,5 @@
 package com.strumenta.antlrkotlin.runtime
 
 // TODO(Edoardo): make thread safe at some point
-public actual typealias CopyOnWriteArrayList<E> = ArrayList<E>
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+internal actual typealias CopyOnWriteArrayList<E> = ArrayList<E>

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
@@ -3,4 +3,5 @@
 package com.strumenta.antlrkotlin.runtime
 
 // TODO(Edoardo): implement real identity comparison
-public actual typealias IdentityHashMap<K, V> = HashMap<K, V>
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+internal actual typealias IdentityHashMap<K, V> = HashMap<K, V>

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -7,7 +7,7 @@ import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
 @OptIn(ExperimentalContracts::class)
-public actual inline fun <R> synchronized(lock: Any, block: () -> R): R {
+internal actual inline fun <R> synchronized(lock: Any, block: () -> R): R {
   contract {
     callsInPlace(block, InvocationKind.EXACTLY_ONCE)
   }

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
@@ -1,9 +1,9 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package com.strumenta.antlrkotlin.runtime
 
 // TODO(Edoardo): implement real weak keys.
 //  See kotlinlang.org/api/latest/jvm/stdlib/kotlin.native.ref
 //  for classes and functions useful for a possible implementation
-public actual typealias WeakHashMap<K, V> = HashMap<K, V>
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+internal actual typealias WeakHashMap<K, V> = HashMap<K, V>

--- a/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
+++ b/antlr-kotlin-runtime/src/wasmJsMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
@@ -3,4 +3,5 @@
 package com.strumenta.antlrkotlin.runtime
 
 // TODO(Edoardo): implement real identity comparison
-public actual typealias IdentityHashMap<K, V> = HashMap<K, V>
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+internal actual typealias IdentityHashMap<K, V> = HashMap<K, V>

--- a/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
+++ b/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/CopyOnWriteArrayList.kt
@@ -3,4 +3,5 @@
 package com.strumenta.antlrkotlin.runtime
 
 // Note(Edoardo): WASI is single threaded at the moment, so a normal list is good enough
-public actual typealias CopyOnWriteArrayList<E> = ArrayList<E>
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+internal actual typealias CopyOnWriteArrayList<E> = ArrayList<E>

--- a/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
+++ b/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/IdentityHashMap.kt
@@ -3,4 +3,5 @@
 package com.strumenta.antlrkotlin.runtime
 
 // TODO(Edoardo): implement real identity comparison
-public actual typealias IdentityHashMap<K, V> = HashMap<K, V>
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+internal actual typealias IdentityHashMap<K, V> = HashMap<K, V>

--- a/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -8,7 +8,7 @@ import kotlin.contracts.contract
 
 // Not necessary for WASI. Single threaded.
 @OptIn(ExperimentalContracts::class)
-public actual inline fun <R> synchronized(lock: Any, block: () -> R): R {
+internal actual inline fun <R> synchronized(lock: Any, block: () -> R): R {
   contract {
     callsInPlace(block, InvocationKind.EXACTLY_ONCE)
   }

--- a/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
+++ b/antlr-kotlin-runtime/src/wasmWasiMain/kotlin/com/strumenta/antlrkotlin/runtime/WeakHashMap.kt
@@ -3,4 +3,5 @@
 package com.strumenta.antlrkotlin.runtime
 
 // TODO(Edoardo): implement real weak keys
-public actual typealias WeakHashMap<K, V> = HashMap<K, V>
+@Suppress("ACTUAL_WITHOUT_EXPECT")
+internal actual typealias WeakHashMap<K, V> = HashMap<K, V>


### PR DESCRIPTION
Reasoning:

- `synchronized`: it's there because of a 1:1 translation from the Java runtime. 
  I want to be free to swap it with kotlinx-atomicfu utilities at some point.
- codepoint functions: we only use those functions in very specialized places, and making them internal means we can also make them inline.
- `assert`: same reasoning as `synchronized`. At some point the Kotlin stdlib will offer a proper multiplatform assert.
- `Collections`: it's there because of a 1:1 translation from the Java runtime. I want to be able to get rid of it anytime.
- `CopyOnWriteArrayList`, `IdentityHashMap`, `WeakHashMap`: internal details that might be changed anytime.