### PR TITLE
Restore pre-1.0.0 behavior for codepoint funs and ObjectEqualityComparator

### DIFF
--- a/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/CodePoint.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/CodePoint.kt
@@ -11,14 +11,14 @@ internal const val MIN_LOW_SURROGATE: Int = 0xDC00
 internal const val HIGH_SURROGATE_ENCODE_OFFSET: Int =
   (MIN_HIGH_SURROGATE - (MIN_SUPPLEMENTARY_CODE_POINT_ ushr 10))
 
-internal inline fun isBmpCodePoint(codePoint: Int): Boolean =
+internal fun isBmpCodePoint(codePoint: Int): Boolean =
   codePoint ushr 16 == 0
 
-internal inline fun highSurrogate(codePoint: Int): Char =
+internal fun highSurrogate(codePoint: Int): Char =
   ((codePoint ushr 10) + HIGH_SURROGATE_ENCODE_OFFSET).toChar()
 
-internal inline fun lowSurrogate(codePoint: Int): Char =
+internal fun lowSurrogate(codePoint: Int): Char =
   ((codePoint and 0x3FF) + MIN_LOW_SURROGATE).toChar()
 
-internal inline fun isValidCodePoint(codePoint: Int): Boolean =
+internal fun isValidCodePoint(codePoint: Int): Boolean =
   codePoint in 0..MAX_CODE_POINT_

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/LexerATNConfig.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/LexerATNConfig.kt
@@ -1,6 +1,5 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package org.antlr.v4.kotlinruntime.atn
 
 import org.antlr.v4.kotlinruntime.misc.MurmurHash
@@ -89,7 +88,7 @@ public class LexerATNConfig : ATNConfig {
       return false
     }
 
-    if (!ObjectEqualityComparator.equals(lexerActionExecutor, other.lexerActionExecutor)) {
+    if (!ObjectEqualityComparator.INSTANCE.equals(lexerActionExecutor, other.lexerActionExecutor)) {
       return false
     }
 

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/OrderedATNConfigSet.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/atn/OrderedATNConfigSet.kt
@@ -1,6 +1,5 @@
 // Copyright 2017-present Strumenta and contributors, licensed under Apache 2.0.
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
-
 package org.antlr.v4.kotlinruntime.atn
 
 import org.antlr.v4.kotlinruntime.misc.ObjectEqualityComparator
@@ -9,7 +8,7 @@ import org.antlr.v4.kotlinruntime.misc.ObjectEqualityComparator
  * @author Sam Harwell
  */
 public class OrderedATNConfigSet : ATNConfigSet() {
-  public class LexerConfigHashSet : AbstractConfigHashSet(ObjectEqualityComparator)
+  public class LexerConfigHashSet : AbstractConfigHashSet(ObjectEqualityComparator.INSTANCE)
 
   init {
     configLookup = LexerConfigHashSet()

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/Array2DHashSet.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/Array2DHashSet.kt
@@ -10,7 +10,7 @@ import kotlin.math.floor
  */
 @Suppress("MemberVisibilityCanBePrivate")
 public open class Array2DHashSet<T>(
-  protected val comparator: AbstractEqualityComparator<T> = ObjectEqualityComparator,
+  protected val comparator: AbstractEqualityComparator<T> = ObjectEqualityComparator.INSTANCE,
   protected val initialCapacity: Int = INITIAL_CAPACITY,
   protected val initialBucketCapacity: Int = INITIAL_BUCKET_CAPACITY,
 ) : MutableSet<T> {

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/FlexibleHashMap.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/FlexibleHashMap.kt
@@ -9,7 +9,7 @@ import kotlin.math.floor
  */
 @Suppress("MemberVisibilityCanBePrivate", "CanBeParameter")
 public open class FlexibleHashMap<K, V>(
-  protected val comparator: AbstractEqualityComparator<K> = ObjectEqualityComparator,
+  protected val comparator: AbstractEqualityComparator<K> = ObjectEqualityComparator.INSTANCE,
   public val initialCapacity: Int = INITIAL_CAPACITY,
   public val initialBucketCapacity: Int = INITIAL_BUCKET_CAPACITY,
 ) : MutableMap<K, V> {

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/ObjectEqualityComparator.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/org/antlr/v4/kotlinruntime/misc/ObjectEqualityComparator.kt
@@ -2,14 +2,21 @@
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
 package org.antlr.v4.kotlinruntime.misc
 
+import kotlin.jvm.JvmField
+
 /**
  * This default implementation of [EqualityComparator] uses object equality
  * for comparisons by calling [Any.hashCode] and [Any.equals].
  *
  * @author Sam Harwell
  */
-public object ObjectEqualityComparator : AbstractEqualityComparator<Any?>() {
-  override fun hashCode(obj: Any?): Int =
+public class ObjectEqualityComparator<in T> : AbstractEqualityComparator<T>() {
+  public companion object {
+    @JvmField
+    public val INSTANCE: ObjectEqualityComparator<Any?> = ObjectEqualityComparator()
+  }
+
+  override fun hashCode(obj: T): Int =
     obj?.hashCode() ?: 0
 
   /**
@@ -21,6 +28,6 @@ public object ObjectEqualityComparator : AbstractEqualityComparator<Any?>() {
    *
    * Otherwise, this method returns the result of `a == b`.
    */
-  override fun equals(a: Any?, b: Any?): Boolean =
+  override fun equals(a: T?, b: T?): Boolean =
     (a == null && b == null) || a == b
 }


### PR DESCRIPTION
After making `ObjectEqualityComparator` an object, I have noticed the outputted code (and the code that's actually invoked) changed.

See the diff. Left 1.0.0-RC4 / Right 1.0.0

![image](https://github.com/user-attachments/assets/ab8971d5-f548-4871-a7fc-08feec295311)

So in 1.0.0 a call to `ObjectEqualityComparator.equals` goes through:
```text
f2s(a, b)
  y30(a, b)
   equals(a, b)
```
Compared to just
```text
f2s(a, b)
  equals(a, b)
```
In RC4. There is also that weird:
```js
var tmp = (a == null ? true : !(a == null)) ? a : THROW_CCE();
```
which I don't understand. Why would a `ClassCastException` be thrown there?  
So I thought that it's better to revert it.