### PR TITLE
Prevent AntlrWorkerManager to explode with Gradle 8.12

### DIFF
--- a/antlr-kotlin-gradle-plugin/src/main/kotlin/com/strumenta/antlrkotlin/gradle/internal/AntlrWorkerManager.kt
+++ b/antlr-kotlin-gradle-plugin/src/main/kotlin/com/strumenta/antlrkotlin/gradle/internal/AntlrWorkerManager.kt
@@ -37,7 +37,11 @@ internal class AntlrWorkerManager {
     javaCommand.workingDir = workingDir
     javaCommand.maxHeapSize = spec.maxHeapSize
     javaCommand.systemProperty("ANTLR_DO_NOT_EXIT", "true")
-    javaCommand.redirectErrorStream()
+    try {
+      javaCommand.redirectErrorStream()
+    } catch (t: Throwable) {
+      System.err.println("Error stream cannot be redirected: ${t.message}")
+    }
 
     return builder.build()
   }


### PR DESCRIPTION
This is a workaround for the (unexplicable) exception happening when using the Gradle plugin from Gradle 8.12

Fix #201 