### PR TITLE
native synchronized

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ or use the [com.strumenta.antlr-kotlin][1] plugin, which instructs ANTLR automat
 The Kotlin runtime for the Kotlin target is derived from the Java runtime, and is built
 as a multiplatform project running on JVM, JS, WebAssembly (including WASI), and Native.
 
-> [!TIP]
-> Starting from version 1.1.0, ANTLR Kotlin is fully thread-safe.
+> [!WARNING]
+> The Kotlin ANTLR runtime is **not** thread safe
 
 The supported Native platforms are:
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ or use the [com.strumenta.antlr-kotlin][1] plugin, which instructs ANTLR automat
 The Kotlin runtime for the Kotlin target is derived from the Java runtime, and is built
 as a multiplatform project running on JVM, JS, WebAssembly (including WASI), and Native.
 
-> [!WARNING]  
-> The Kotlin ANTLR runtime is **not** thread safe
+> [!TIP]
+> Starting from version 1.1.0, ANTLR Kotlin is fully thread-safe.
 
 The supported Native platforms are:
 
@@ -51,7 +51,7 @@ The supported Native platforms are:
 |                   | tvosX64               |                    |
 |                   | tvosArm64             |                    |
 
-> [!NOTE]  
+> [!NOTE]
 > The `linuxArm32Hfp` platform is deprecated
 
 ## Gradle Setup
@@ -143,7 +143,7 @@ To start using ANTLR Kotlin:
 The [antlr-kotlin-benchmarks](./antlr-kotlin-benchmarks) module contains benchmarking code
 for JVM, JS, WebAssembly and Native targets.
 
-The benchmark scenario has been adapted from [antlr4ng][2].  
+The benchmark scenario has been adapted from [antlr4ng][2].
 To run benchmarks, use:
 ```
 ./gradlew :antlr-kotlin-benchmarks:jvmBenchmark

--- a/antlr-kotlin-runtime/build.gradle.kts
+++ b/antlr-kotlin-runtime/build.gradle.kts
@@ -26,6 +26,14 @@ kotlin {
     commonTest {
       dependencies {
         implementation(kotlin("test"))
+        implementation(libs.kotlinx.coroutines.core)
+        implementation(libs.kotlinx.coroutines.test)
+      }
+    }
+
+    nativeMain {
+      dependencies {
+        implementation(libs.atomicfu)
       }
     }
   }

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -2,6 +2,11 @@
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
 package com.strumenta.antlrkotlin.runtime
 
-// Builds perfectly fine with AtomicFu 0.33, and the native implementation is simple enough to reason about
-// handles contention well enough and does not grow abundantly in real-world use cases
+/**
+ * Multiplatform `synchronized` (monitor-based locking) implementation
+ * * On the JVM this delegates to Java's `synchronized`
+ * * On Web targets, this is a NOOP, as there is no shared memory concurrency
+ * * On native targets, this uses AtomicFU and a simple enough custom implementation that handles
+ *   realistic uses cases well enough and is easy to reason about
+ */
 internal expect inline fun <R> synchronized(lock: Any, block: () -> R): R

--- a/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/antlr-kotlin-runtime/src/commonMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -2,9 +2,6 @@
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
 package com.strumenta.antlrkotlin.runtime
 
-// TODO(Edoardo): wait for AtomicFU 0.24.0, so that we can
-//  integrate it without buildscript hacks.
-//  Also, how are we going to use the "lock" parameter?
-//  Probably it makes sense to just tell consumers the
-//  Kotlin Native implementation is not thread safe.
+// Builds perfectly fine with AtomicFu 0.33, and the native implementation is simple enough to reason about
+// handles contention well enough and does not grow abundantly in real-world use cases
 internal expect inline fun <R> synchronized(lock: Any, block: () -> R): R

--- a/antlr-kotlin-runtime/src/commonTest/kotlin/com/strumenta/antlrkotlin/runtime/SynchronizedTest.kt
+++ b/antlr-kotlin-runtime/src/commonTest/kotlin/com/strumenta/antlrkotlin/runtime/SynchronizedTest.kt
@@ -1,0 +1,277 @@
+package com.strumenta.antlrkotlin.runtime
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.decrementAndFetch
+import kotlin.concurrent.atomics.incrementAndFetch
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+//this file lives here, because we need to make sure it behaves the same on all targets
+
+private typealias ExpectedException = IllegalStateException
+private typealias ExpectedThrowable = AssertionError
+
+@OptIn(ExperimentalAtomicApi::class)
+class SynchronizedTest {
+  @Test
+  fun returnsBlockResultAndInvokesItOnce() {
+    var calls = 0
+
+    val result = synchronized(Any()) {
+      calls++
+      42
+    }
+
+    assertEquals(42, result)
+    assertEquals(1, calls)
+  }
+
+  @Test
+  fun supportsNullResults() {
+    assertNull(synchronized(Any()) { null })
+  }
+
+  @Test
+  fun supportsNonLocalReturns() {
+    val monitor = Any()
+
+    assertEquals(42, nonLocalReturn(monitor))
+    assertEquals(43, synchronized(monitor) { 43 })
+  }
+
+  @Test
+  fun isReentrant() {
+    val monitor = Any()
+
+    assertEquals(42, synchronized(monitor) {
+      synchronized(monitor) {
+        42
+      }
+    })
+  }
+
+  @Test
+  fun releasesNestedAcquisitionWhenItThrows() {
+    val monitor = Any()
+
+    assertEquals(42, synchronized(monitor) {
+      assertFailsWith<ExpectedException> {
+        synchronized(monitor) {
+          throw ExpectedException()
+        }
+      }
+
+      synchronized(monitor) { 42 }
+    })
+  }
+
+  @Test
+  fun propagatesTheSameExceptionAndReleasesTheMonitor() {
+    val monitor = Any()
+    val expected = ExpectedException()
+
+    val actual = assertFailsWith<ExpectedException> {
+      synchronized(monitor) {
+        throw expected
+      }
+    }
+
+    assertSame(expected, actual)
+    assertEquals(42, synchronized(monitor) { 42 })
+  }
+
+  @Test
+  fun propagatesArbitraryThrowablesAndReleasesTheMonitor() {
+    val monitor = Any()
+    val expected = ExpectedThrowable("expected")
+
+    val actual = assertFailsWith<ExpectedThrowable> {
+      synchronized(monitor) {
+        throw expected
+      }
+    }
+
+    assertSame(expected, actual)
+    assertEquals(42, synchronized(monitor) { 42 })
+  }
+
+  @Test
+  fun propagatesCancellationAndReleasesTheMonitor() {
+    val monitor = Any()
+    val expected = CancellationException("expected")
+
+    val actual = assertFailsWith<CancellationException> {
+      synchronized(monitor) {
+        throw expected
+      }
+    }
+
+    assertSame(expected, actual)
+    assertEquals(42, synchronized(monitor) { 42 })
+  }
+
+  @Test
+  fun supportsDeepReentrancy() {
+    val monitor = Any()
+    var calls = 0
+
+    fun enter(depth: Int) {
+      synchronized(monitor) {
+        calls++
+        if (depth > 0) {
+          enter(depth - 1)
+        }
+      }
+    }
+
+    enter(REENTRANCY_DEPTH)
+    assertEquals(REENTRANCY_DEPTH + 1, calls)
+    assertEquals(42, synchronized(monitor) { 42 })
+  }
+
+  @Test
+  fun repeatedlyAcquiresReleasedAndTransientMonitors() {
+    val reusedMonitor = Any()
+    var calls = 0
+
+    repeat(MONITOR_CHURN) {
+      synchronized(reusedMonitor) { calls++ }
+      synchronized(Any()) { calls++ }
+    }
+
+    assertEquals(MONITOR_CHURN * 2, calls)
+  }
+
+  @Test
+  fun doesNotInvokeMonitorEqualsOrHashCode() {
+    val monitor = HostileMonitor()
+    val otherMonitor = HostileMonitor()
+
+    repeat(100) {
+      synchronized(monitor) {
+        synchronized(monitor) { }
+        synchronized(otherMonitor) { }
+      }
+    }
+  }
+
+  @Test
+  fun serializesContendingCoroutines() = runTest {
+    val state = State()
+    val inside = AtomicInt(0)
+
+    coroutineScope {
+      repeat(WORKERS) {
+        launch(Dispatchers.Default) {
+          repeat(INCREMENTS) { iteration ->
+            if (iteration % YIELD_EVERY == 0) {
+              yield()
+            }
+
+            synchronized(state.monitor) {
+              assertEquals(1, inside.incrementAndFetch())
+              try {
+                synchronized(state.monitor) {
+                  state.counter++
+                }
+              } finally {
+                assertEquals(0, inside.decrementAndFetch())
+              }
+            }
+          }
+        }
+      }
+    }
+
+    assertEquals(WORKERS * INCREMENTS, state.counter)
+  }
+
+  @Test
+  fun releasesTheMonitorAfterExceptionsUnderContention() = runTest {
+    val state = State()
+
+    coroutineScope {
+      repeat(WORKERS) {
+        launch(Dispatchers.Default) {
+          repeat(INCREMENTS) { iteration ->
+            try {
+              synchronized(state.monitor) {
+                if (iteration % FAIL_EVERY == 0) {
+                  throw ExpectedException()
+                }
+
+                state.counter++
+              }
+            } catch (_: ExpectedException) {
+              // Expected.
+            }
+          }
+        }
+      }
+    }
+
+    val failuresPerWorker = (INCREMENTS + FAIL_EVERY - 1) / FAIL_EVERY
+    assertEquals(WORKERS * (INCREMENTS - failuresPerWorker), state.counter)
+  }
+
+  @Test
+  fun synchronizesMultipleMonitorIdentitiesIndependently() = runTest {
+    val states = List(MONITORS) { State() }
+
+    coroutineScope {
+      repeat(WORKERS) { worker ->
+        launch(Dispatchers.Default) {
+          val state = states[worker % states.size]
+
+          repeat(INCREMENTS) {
+            synchronized(state.monitor) {
+              state.counter++
+            }
+          }
+        }
+      }
+    }
+
+    val workersPerMonitor = WORKERS / MONITORS
+    states.forEach { state ->
+      assertEquals(workersPerMonitor * INCREMENTS, state.counter)
+    }
+  }
+
+  private fun nonLocalReturn(monitor: Any): Int {
+    synchronized(monitor) {
+      return 42
+    }
+  }
+
+  private class State {
+    val monitor = Any()
+    var counter = 0
+  }
+
+  private class HostileMonitor {
+    override fun equals(other: Any?): Boolean = error("Monitor equality must not be used")
+
+    override fun hashCode(): Int = error("Monitor hash code must not be used")
+  }
+
+  private companion object {
+    const val WORKERS = 8
+    const val MONITORS = 4
+    const val INCREMENTS = 2_000
+    const val YIELD_EVERY = 8
+    const val FAIL_EVERY = 17
+    const val REENTRANCY_DEPTH = 100
+    const val MONITOR_CHURN = 2_000
+  }
+}

--- a/antlr-kotlin-runtime/src/commonTest/kotlin/com/strumenta/antlrkotlin/runtime/SynchronizedTest.kt
+++ b/antlr-kotlin-runtime/src/commonTest/kotlin/com/strumenta/antlrkotlin/runtime/SynchronizedTest.kt
@@ -16,10 +16,19 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 
-//this file lives here, because we need to make sure it behaves the same on all targets
+// This file lives here, because we need to make sure it behaves the same on all targets
 
-private typealias ExpectedException = IllegalStateException
-private typealias ExpectedThrowable = AssertionError
+private typealias SynchronizationExpectedException = IllegalStateException
+private typealias SynchronizationExpectedThrowable = AssertionError
+
+private const val WORKERS = 8
+private const val MONITORS = 4
+private const val INCREMENTS = 2_000
+private const val YIELD_EVERY = 8
+private const val FAIL_EVERY = 17
+private const val REENTRANCY_DEPTH = 100
+private const val MONITOR_CHURN = 2_000
+
 
 @OptIn(ExperimentalAtomicApi::class)
 class SynchronizedTest {
@@ -65,9 +74,9 @@ class SynchronizedTest {
     val monitor = Any()
 
     assertEquals(42, synchronized(monitor) {
-      assertFailsWith<ExpectedException> {
+      assertFailsWith<SynchronizationExpectedException> {
         synchronized(monitor) {
-          throw ExpectedException()
+          throw SynchronizationExpectedException()
         }
       }
 
@@ -78,9 +87,9 @@ class SynchronizedTest {
   @Test
   fun propagatesTheSameExceptionAndReleasesTheMonitor() {
     val monitor = Any()
-    val expected = ExpectedException()
+    val expected = SynchronizationExpectedException()
 
-    val actual = assertFailsWith<ExpectedException> {
+    val actual = assertFailsWith<SynchronizationExpectedException> {
       synchronized(monitor) {
         throw expected
       }
@@ -93,9 +102,9 @@ class SynchronizedTest {
   @Test
   fun propagatesArbitraryThrowablesAndReleasesTheMonitor() {
     val monitor = Any()
-    val expected = ExpectedThrowable("expected")
+    val expected = SynchronizationExpectedThrowable("expected")
 
-    val actual = assertFailsWith<ExpectedThrowable> {
+    val actual = assertFailsWith<SynchronizationExpectedThrowable> {
       synchronized(monitor) {
         throw expected
       }
@@ -207,12 +216,12 @@ class SynchronizedTest {
             try {
               synchronized(state.monitor) {
                 if (iteration % FAIL_EVERY == 0) {
-                  throw ExpectedException()
+                  throw SynchronizationExpectedException()
                 }
 
                 state.counter++
               }
-            } catch (_: ExpectedException) {
+            } catch (_: SynchronizationExpectedException) {
               // Expected.
             }
           }
@@ -263,15 +272,5 @@ class SynchronizedTest {
     override fun equals(other: Any?): Boolean = error("Monitor equality must not be used")
 
     override fun hashCode(): Int = error("Monitor hash code must not be used")
-  }
-
-  private companion object {
-    const val WORKERS = 8
-    const val MONITORS = 4
-    const val INCREMENTS = 2_000
-    const val YIELD_EVERY = 8
-    const val FAIL_EVERY = 17
-    const val REENTRANCY_DEPTH = 100
-    const val MONITOR_CHURN = 2_000
   }
 }

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -34,10 +34,10 @@ internal class Monitor(
         val monitor = registry.firstOrNull { it.instance === instance }
           ?: Monitor(instance).also(registry::add) // create if not found
 
-        monitor.refCount++ //increment ref count in any case
+        monitor.refCount++ // Increment ref count in any case
         monitor
       }
-      toBeReturned.lock.lock()  /*lock OUTSIDE registry lock to avoid deadlocks*/
+      toBeReturned.lock.lock()  // Lock OUTSIDE registry lock to avoid deadlocks
       return toBeReturned
     }
   }
@@ -92,10 +92,19 @@ private inline fun checkWithReport(value: Boolean, body: () -> String): Unit = c
   "Please report this bug at https://github.com/Strumenta/antlr-kotlin/issues/new?title=$ISSUE_TITLE&body=${body()}"
 }
 
-private const val ISSUE_TITLE = "Native%20synchronized%20inconsistent%20state"
-private const val BODY_FREE = "Freeing%20a%20monitor%20produces%20an%20inconsistent%20state." +
-  "%0A%0ASteps%20to%20reproduce%3A%0A%60%60%60kotlin%0A%2F%2Fyour%20reproducer%20here%0A%60%60%60%0A%0A" +
-  "%40JesusMcCloud%20PTAL.%0A" //this last newline is so that IDEA will not add the next line to the clickable link
-private const val BODY_RELEASE = "Releasing%20a%20monitor%20produces%20an%20inconsistent%20state." +
-  "%0A%0ASteps%20to%20reproduce%3A%0A%60%60%60kotlin%0A%2F%2Fyour%20reproducer%20here%0A%60%60%60%0A%0A" +
-  "%40JesusMcCloud%20PTAL.%0A" //this last newline is so that IDEA will not add the next line to the clickable link
+private val ISSUE_TITLE = "Native synchronized inconsistent state".basicUrlEscape()
+private val BODY_FREE = ("Freeing a monitor produces an inconsistent state." +
+  "\n\n## Steps to reproduce:\n\n```kotlin\n// your reproducer here\n```\n\n" +
+  "@JesusMcCloud PTAL.\n").basicUrlEscape() //this last newline is so that IDEA will not add the next line to the clickable link
+private val BODY_RELEASE = ("Releasing a monitor produces an inconsistent state." +
+  "\n\n## Steps to reproduce:\n\n```kotlin\n// your reproducer here\n```\n\n" +
+  "@JesusMcCloud PTAL.\n").basicUrlEscape() //this last newline is so that IDEA will not add the next line to the clickable link
+
+private fun String.basicUrlEscape(): String = this
+  .replace(" ", "%20")
+  .replace("\n", "%0A")
+  .replace(":", "%3A")
+  .replace("`", "%60")
+  .replace("/", "%2F")
+  .replace("@", "%40")
+  .replace("#", "%23")

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -24,9 +24,12 @@ internal class Monitor(
      * Otherwise, it creates a new monitor and acquires it.
      */
     fun acquire(instance: Any): Monitor = registryLock.withLock {
-      //linear search. certified good enough
+      // Linear search keeps things simple. Could be optimized using a custom TreeSet or similar to reduce complexity to O(log(n))
+      // but how critical is this really in the hot path and how many workers will realistically cause contention?!
+      // This added complexity (since we cannot use hashCode or equals, but we'll need to compare identity)
+      // will be worth it only if we go into the thousands of concurrent accesses in a performance-critical hot path
       (registry.firstOrNull { it.instance === instance }
-      //create if not found
+      // create if not found
         ?: Monitor(instance).also(registry::add)
         ).apply { refCount++ } //increment ref count in any case
     }.apply { lock.lock() /*lock OUTSIDE registry lock to avoid deadlocks*/ }
@@ -38,11 +41,11 @@ internal class Monitor(
    * Releases the held lock and cleans up the registry if necessary, freeing
    */
   fun release() {
-    //FIRST we release the held lock
+    // FIRST we release the held lock
     lock.unlock()
-    //only THEN we decrement the ref count and clean up if necessary, INSIDE the registry lock
+    // only THEN we decrement the ref count and clean up if necessary, INSIDE the registry lock
     registryLock.withLock {
-      //Fail hard adn notify
+      // Fail hard and notify
       checkWithReport(refCount > 0) { BODY_RELEASE }
 
       if (--refCount == 0) free()
@@ -56,7 +59,7 @@ internal class Monitor(
   @Suppress("NOTHING_TO_INLINE")
   private inline fun free() {
     val index = registry.indexOfFirst { it === this }
-    //fail hard and notify
+    // Fail hard and notify
     checkWithReport(index >= 0) { BODY_FREE } //fail hard!
     registry.removeAt(index)
   }
@@ -66,7 +69,7 @@ internal class Monitor(
 @OptIn(ExperimentalContracts::class)
 internal actual inline fun <R> synchronized(lock: Any, block: () -> R): R {
   contract {
-    callsInPlace(block, InvocationKind.AT_MOST_ONCE)
+    callsInPlace(block, InvocationKind.EXACTLY_ONCE)
   }
   val monitor = Monitor.acquire(lock)
   try {

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -2,15 +2,91 @@
 // Copyright 2024-present Strumenta and contributors, licensed under BSD 3-Clause.
 package com.strumenta.antlrkotlin.runtime
 
+import kotlinx.atomicfu.locks.ReentrantLock
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
+internal class Monitor(
+  private val instance: Any,
+) {
+  private var refCount: Int = 0
+  private val lock: ReentrantLock = reentrantLock()
+
+  companion object {
+    private val registryLock = reentrantLock()
+    private val registry = ArrayList<Monitor>()
+
+    /**
+     * Acquires a [Monitor] for the given [instance]. If one exists (i.e. if it is held by another thread), this call blocks until the monitor is released.
+     * Otherwise, it creates a new monitor and acquires it.
+     */
+    fun acquire(instance: Any): Monitor = registryLock.withLock {
+      //linear search. certified good enough
+      (registry.firstOrNull { it.instance === instance }
+      //create if not found
+        ?: Monitor(instance).also(registry::add)
+        ).apply { refCount++ } //increment ref count in any case
+    }.apply { lock.lock() /*lock OUTSIDE registry lock to avoid deadlocks*/ }
+
+  }
+
+  //this lives below companion, so the source code flows nicely: first acquire, below release
+  /**
+   * Releases the held lock and cleans up the registry if necessary, freeing
+   */
+  fun release() {
+    //FIRST we release the held lock
+    lock.unlock()
+    //only THEN we decrement the ref count and clean up if necessary, INSIDE the registry lock
+    registryLock.withLock {
+      //Fail hard adn notify
+      checkWithReport(refCount > 0) { BODY_RELEASE }
+
+      if (--refCount == 0) free()
+    }
+  }
+
+  //Yes, this is noisy, and yes, this changes nothing functionally, but all of this is sensitive code and the interplay
+  //between functions is delicate, so being explicit is worth it for clarity: No hidden behaviour; every minute detail
+  //of every nuance of every step is clearly visible here; self-contained in a single file across 65 LoC including
+  //comments
+  @Suppress("NOTHING_TO_INLINE")
+  private inline fun free() {
+    val index = registry.indexOfFirst { it === this }
+    //fail hard and notify
+    checkWithReport(index >= 0) { BODY_FREE } //fail hard!
+    registry.removeAt(index)
+  }
+}
+
+
 @OptIn(ExperimentalContracts::class)
 internal actual inline fun <R> synchronized(lock: Any, block: () -> R): R {
   contract {
-    callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    callsInPlace(block, InvocationKind.AT_MOST_ONCE)
   }
-
-  return block()
+  val monitor = Monitor.acquire(lock)
+  try {
+    return block()
+  } finally {
+    monitor.release()
+  }
 }
+
+//The easier it is to report, the more likely people will do it
+
+@Suppress("NOTHING_TO_INLINE")
+private inline fun checkWithReport(value: Boolean, body: () -> String): Unit = check(value) {
+  "Please report this bug at https://github.com/Strumenta/antlr-kotlin/issues/new?title=$ISSUE_TITLE&body=${body()}"
+}
+
+private const val ISSUE_TITLE = "Native%20synchronized%20inconsistent%20state"
+private const val BODY_FREE = "Freeing%20a%20monitor%20produces%20an%20inconsistent%20state." +
+  "%0A%0ASteps%20to%20reproduce%3A%0A%60%60%60kotlin%0A%2F%2Fyour%20reproducer%20here%0A%60%60%60%0A%0A" +
+  "%40JesusMcCloud%20PTAL.%0A" //this last newline is so that IDEA will not add the next line to the clickable link
+private const val BODY_RELEASE = "Releasing%20a%20monitor%20produces%20an%20inconsistent%20state." +
+  "%0A%0ASteps%20to%20reproduce%3A%0A%60%60%60kotlin%0A%2F%2Fyour%20reproducer%20here%0A%60%60%60%0A%0A" +
+  "%40JesusMcCloud%20PTAL.%0A" //this last newline is so that IDEA will not add the next line to the clickable link

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -23,17 +23,23 @@ internal class Monitor(
      * Acquires a [Monitor] for the given [instance]. If one exists (i.e. if it is held by another thread), this call blocks until the monitor is released.
      * Otherwise, it creates a new monitor and acquires it.
      */
-    fun acquire(instance: Any): Monitor = registryLock.withLock {
-      // Linear search keeps things simple. Could be optimized using a custom TreeSet or similar to reduce complexity to O(log(n))
-      // but how critical is this really in the hot path and how many workers will realistically cause contention?!
-      // This added complexity (since we cannot use hashCode or equals, but we'll need to compare identity)
-      // will be worth it only if we go into the thousands of concurrent accesses in a performance-critical hot path
-      (registry.firstOrNull { it.instance === instance }
-      // create if not found
-        ?: Monitor(instance).also(registry::add)
-        ).apply { refCount++ } //increment ref count in any case
-    }.apply { lock.lock() /*lock OUTSIDE registry lock to avoid deadlocks*/ }
+    fun acquire(instance: Any): Monitor {
 
+      // Avoid shadowing/nameclashes in potential future refactor
+      val toBeReturned = registryLock.withLock {
+        // Linear search keeps things simple. Could be optimized using a custom TreeSet or similar to reduce complexity to O(log(n))
+        // but how critical is this really in the hot path and how many workers will realistically cause contention?!
+        // This added complexity (since we cannot use hashCode or equals, but we'll need to compare identity)
+        // will be worth it only if we go into the thousands of concurrent accesses in a performance-critical hot path
+        val monitor = registry.firstOrNull { it.instance === instance }
+          ?: Monitor(instance).also(registry::add) // create if not found
+
+        monitor.refCount++ //increment ref count in any case
+        monitor
+      }
+      toBeReturned.lock.lock()  /*lock OUTSIDE registry lock to avoid deadlocks*/
+      return toBeReturned
+    }
   }
 
   //this lives below companion, so the source code flows nicely: first acquire, below release

--- a/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
+++ b/antlr-kotlin-runtime/src/nativeMain/kotlin/com/strumenta/antlrkotlin/runtime/Synchronized.kt
@@ -42,7 +42,7 @@ internal class Monitor(
     }
   }
 
-  //this lives below companion, so the source code flows nicely: first acquire, below release
+  // This lives below companion, so the source code flows nicely: first acquire, below release
   /**
    * Releases the held lock and cleans up the registry if necessary, freeing
    */
@@ -58,10 +58,10 @@ internal class Monitor(
     }
   }
 
-  //Yes, this is noisy, and yes, this changes nothing functionally, but all of this is sensitive code and the interplay
-  //between functions is delicate, so being explicit is worth it for clarity: No hidden behaviour; every minute detail
-  //of every nuance of every step is clearly visible here; self-contained in a single file across 65 LoC including
-  //comments
+  // Yes, this is noisy, and yes, this changes nothing functionally, but all of this is sensitive code and the interplay
+  // between functions is delicate, so being explicit is worth it for clarity: No hidden behaviour; every minute detail
+  // of every nuance of every step is clearly visible here; self-contained in a single file across 65 LoC including
+  // comments
   @Suppress("NOTHING_TO_INLINE")
   private inline fun free() {
     val index = registry.indexOfFirst { it === this }
@@ -85,7 +85,7 @@ internal actual inline fun <R> synchronized(lock: Any, block: () -> R): R {
   }
 }
 
-//The easier it is to report, the more likely people will do it
+// The easier it is to report, the more likely people will do it
 
 @Suppress("NOTHING_TO_INLINE")
 private inline fun checkWithReport(value: Boolean, body: () -> String): Unit = check(value) {

--- a/antlr-kotlin-runtime/src/nativeTest/kotlin/com/strumenta/antlrkotlin/runtime/SynchronizedTest.kt
+++ b/antlr-kotlin-runtime/src/nativeTest/kotlin/com/strumenta/antlrkotlin/runtime/SynchronizedTest.kt
@@ -1,0 +1,48 @@
+package com.strumenta.antlrkotlin.runtime
+
+import kotlin.native.concurrent.ObsoleteWorkersApi
+import kotlin.native.concurrent.TransferMode
+import kotlin.native.concurrent.Worker
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+
+private class State {
+  val monitor = Any()
+  var counter = 0
+}
+
+private fun increment(state: State) {
+  synchronized(state.monitor) {
+    synchronized(state.monitor) {
+      state.counter++
+    }
+  }
+}
+
+const val WORKERS = 64
+const val INCREMENTS = 10_000
+
+@OptIn(ObsoleteWorkersApi::class)
+class SynchronizedThreadTest {
+  @Test
+  fun synchronizesThreads() {
+    repeat(5) {
+      val state = State()
+      val workers = List(WORKERS) { Worker.start() }
+
+      try {
+        workers.map { worker ->
+          worker.execute(TransferMode.SAFE, { state }) { sharedState ->
+            repeat(INCREMENTS) {
+              increment(sharedState)
+            }
+          }
+        }.forEach { it.result }
+      } finally {
+        workers.forEach { it.requestTermination().result }
+      }
+      assertEquals(WORKERS * INCREMENTS, state.counter)
+    }
+  }
+}

--- a/antlr-kotlin-runtime/src/nativeTest/kotlin/com/strumenta/antlrkotlin/runtime/SynchronizedTest.kt
+++ b/antlr-kotlin-runtime/src/nativeTest/kotlin/com/strumenta/antlrkotlin/runtime/SynchronizedTest.kt
@@ -20,8 +20,8 @@ private fun increment(state: State) {
   }
 }
 
-const val WORKERS = 64
-const val INCREMENTS = 10_000
+private const val WORKERS = 64
+private const val INCREMENTS = 10_000
 
 @OptIn(ObsoleteWorkersApi::class)
 class SynchronizedThreadTest {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
 kotlin = "2.3.0"
+atomicfu = "0.33.0"
+kotlinx-coroutines = "1.11.0"
 kotlinx-io = "0.8.2"
 kotlinx-benchmark = "0.4.15"
 kotlinx-resources = "0.14.0"
@@ -11,6 +13,9 @@ gradle-plugin-publish = "2.0.0"
 antlr-kotlin = "1.0.8"
 
 [libraries]
+atomicfu = { group = "org.jetbrains.kotlinx", name = "atomicfu", version.ref = "atomicfu" }
+kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-io-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-io-core", version.ref = "kotlinx-io" }
 kotlinx-benchmark = { group = "org.jetbrains.kotlinx", name = "kotlinx-benchmark-runtime", version.ref = "kotlinx-benchmark" }
 kotlinx-resources = { group = "com.goncalossilva", name = "resources", version.ref = "kotlinx-resources" }


### PR DESCRIPTION
Adds a working `synchronized` (Monitor-based locking) implementation to native targets, allowing for full thread- and coroutine-safety across all targets.

The implementation itself is less than 40 LoC, which should make it really easy to reason about and maintain.

I did not check whether `synchronized` is used throughout the codebase as it should be, s.t. this fix will deliver on its promise or whether the lack of a working `synchronized` primitive lead to it not being applied to all critical sections; I just assumed that it is.

We urgently need this in production -> I will tend to any requested changes ASAP.